### PR TITLE
feat: branch protections and nightly CI schedule

### DIFF
--- a/.github/workflows/enforce-develop-to-main.yml
+++ b/.github/workflows/enforce-develop-to-main.yml
@@ -1,0 +1,16 @@
+name: Enforce develop-to-main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR is from develop
+        if: github.head_ref != 'develop'
+        run: |
+          echo "::error::PRs to main must come from the develop branch, not '${{ github.head_ref }}'."
+          echo "Merge your changes into develop first, then create a PR from develop to main."
+          exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,3 @@ jobs:
   unit_tests:
     needs: setup
     uses: ./.github/workflows/unit_tests.yml
-  integration_tests:
-    needs: setup
-    uses: ./.github/workflows/integration_tests.yml
-  e2e_tests:
-    needs: integration_tests
-    uses: ./.github/workflows/e2e_tests.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,24 @@
+---
+name: Nightly Test Suite
+on:
+  schedule:
+    # Run at 4 AM UTC every day
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-tests
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    uses: ./.github/workflows/setup.yml
+  unit_tests:
+    needs: setup
+    uses: ./.github/workflows/unit_tests.yml
+  integration_tests:
+    needs: setup
+    uses: ./.github/workflows/integration_tests.yml
+  e2e_tests:
+    needs: integration_tests
+    uses: ./.github/workflows/e2e_tests.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Note: Helm tests run on main branch via build-and-test.yml before tagging.
-  # By the time we tag a release, helm tests have already passed.
+  # Run the full test suite before building release artifacts
+  setup:
+    uses: ./.github/workflows/setup.yml
+  unit_tests:
+    needs: setup
+    uses: ./.github/workflows/unit_tests.yml
+  integration_tests:
+    needs: setup
+    uses: ./.github/workflows/integration_tests.yml
+  e2e_tests:
+    needs: integration_tests
+    uses: ./.github/workflows/e2e_tests.yml
 
   build-release-images:
+    needs: [unit_tests, e2e_tests]
     name: Build Release Images
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Add main branch protection: PRs required, unit tests must pass, admin bypass for emergencies
- Enforce develop-to-main: PRs to main must originate from develop branch
- Move integration and e2e tests from per-push to nightly schedule (4 AM UTC + manual dispatch)
- Fast Code Validation now runs only setup + unit tests on push/PR

## Test plan
- [ ] Verify unit tests still run on push to develop
- [ ] Verify nightly workflow appears in Actions tab
- [ ] Verify direct push to main is blocked for non-admins
- [ ] Verify PR from non-develop branch to main fails the check