### PR TITLE
Fix flaky test_release_expired: serialize webhook-delivery queue tests (BROKKR-T-0184)

### DIFF
--- a/.metis/backlog/bugs/BROKKR-T-0184.md
+++ b/.metis/backlog/bugs/BROKKR-T-0184.md
@@ -1,0 +1,70 @@
+---
+id: flaky-test-release-expired-shared-db-race
+level: task
+title: "Flaky test_release_expired: webhook-delivery queue tests race on the shared DB"
+short_code: "BROKKR-T-0184"
+created_at: 2026-05-27T00:00:00+00:00
+updated_at: 2026-05-27T00:00:00+00:00
+parent:
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#bug"
+  - "#phase/completed"
+
+
+exit_criteria_met: true
+initiative_id: NULL
+backlog_category: bug
+---
+
+# Flaky test_release_expired: webhook-delivery queue tests race on the shared DB
+
+## Objective
+
+`dal::webhook_deliveries::test_release_expired` flaked in CI (the v0.5.0
+Release run, 2026-05-27), failing `assert!(released >= 1)` at
+`webhook_deliveries.rs:278` while passing locally and on the PR. Make it
+deterministic.
+
+## Root cause
+
+`TestFixture::new()` connects every test to a **single shared database**, and
+cargo runs integration tests in parallel. The webhook-delivery queue
+operations are **global**, not subscription-scoped:
+
+- `release_expired()` sweeps *all* expired-claim rows.
+- `claim_for_broker(N, …)` / `claim_for_agent(…)` claim from the *global*
+  pending pool.
+
+So a concurrently-running webhook test can release or steal another test's
+rows. `test_release_expired` claims its row with TTL 0, sleeps 100 ms, then
+calls `release_expired()` and asserts it released ≥ 1 — but a parallel test's
+`release_expired()` could already have swept that row, so the count comes back
+0. Product code is correct; the test isolation is wrong.
+
+## Fix
+
+Serialize the webhook-delivery DAL tests against each other with
+`#[serial(webhook_queue)]` (serial_test, already a workspace dep). They run
+one-at-a-time relative to each other — eliminating the shared-queue
+contention — while still parallelising against the rest of the suite. Added
+`serial_test` to `brokkr-broker` dev-dependencies and a module comment
+explaining why.
+
+## Acceptance Criteria
+
+- [x] `test_release_expired` (and the sibling claim/release tests) no longer
+      race on the shared DB
+- [x] `#[serial(webhook_queue)]` on all webhook-delivery DAL tests; module
+      comment explains the shared-global-queue hazard
+- [x] Integration suite green
+
+## Status Updates
+
+### 2026-05-27 — Fixed
+
+Serialized the 21 webhook-delivery DAL tests. Compiles clean; webhook module +
+full integration suite green (recorded in the fix commit). No product change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tera",
  "tokio",

--- a/crates/brokkr-broker/Cargo.toml
+++ b/crates/brokkr-broker/Cargo.toml
@@ -72,3 +72,6 @@ notify = "7"
 # Real-TCP WebSocket client for /internal/ws/agent integration tests (WS-02).
 tokio-tungstenite = "0.24"
 brokkr-wire = { path = "../brokkr-wire" }
+# Serialize integration tests that contend on the shared DB's global webhook
+# delivery queue (claim/release sweeps) so they don't race each other.
+serial_test = { workspace = true }

--- a/crates/brokkr-broker/tests/integration/dal/webhook_deliveries.rs
+++ b/crates/brokkr-broker/tests/integration/dal/webhook_deliveries.rs
@@ -6,7 +6,17 @@
 
 use crate::fixtures::TestFixture;
 use brokkr_models::models::webhooks::{BrokkrEvent, NewWebhookDelivery, NewWebhookSubscription};
+use serial_test::serial;
 use uuid::Uuid;
+
+// These tests share one database (TestFixture connects to a single DB) and the
+// webhook-delivery queue operations `claim_for_broker` / `claim_for_agent` /
+// `release_expired` act on the *global* pending/expired set, not just a single
+// subscription's rows. Run in parallel they race — one test's claim or
+// release sweep steals or releases another's rows (this flaked
+// `test_release_expired`'s `released >= 1` in CI). `#[serial(webhook_queue)]`
+// runs them one-at-a-time relative to each other while still parallelising
+// against the rest of the suite.
 
 fn create_test_subscription(name: &str) -> NewWebhookSubscription {
     NewWebhookSubscription {
@@ -53,6 +63,7 @@ fn create_test_event() -> BrokkrEvent {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_create_delivery() {
     let fixture = TestFixture::new();
 
@@ -83,6 +94,7 @@ fn test_create_delivery() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_create_delivery_with_target_labels() {
     let fixture = TestFixture::new();
 
@@ -108,6 +120,7 @@ fn test_create_delivery_with_target_labels() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_get_delivery() {
     let fixture = TestFixture::new();
 
@@ -134,6 +147,7 @@ fn test_get_delivery() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_claim_for_broker() {
     let fixture = TestFixture::new();
 
@@ -167,6 +181,7 @@ fn test_claim_for_broker() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_claim_for_agent_with_matching_labels() {
     let fixture = TestFixture::new();
 
@@ -201,6 +216,7 @@ fn test_claim_for_agent_with_matching_labels() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_claim_for_agent_without_matching_labels() {
     let fixture = TestFixture::new();
 
@@ -233,6 +249,7 @@ fn test_claim_for_agent_without_matching_labels() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_release_expired() {
     let fixture = TestFixture::new();
 
@@ -293,6 +310,7 @@ fn test_release_expired() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_mark_success() {
     let fixture = TestFixture::new();
 
@@ -320,6 +338,7 @@ fn test_mark_success() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_mark_failed_with_retry() {
     let fixture = TestFixture::new();
 
@@ -348,6 +367,7 @@ fn test_mark_failed_with_retry() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_process_retries() {
     let fixture = TestFixture::new();
 
@@ -418,6 +438,7 @@ fn test_process_retries() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_mark_failed_max_retries_exceeded() {
     let fixture = TestFixture::new();
 
@@ -445,6 +466,7 @@ fn test_mark_failed_max_retries_exceeded() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_list_for_subscription() {
     let fixture = TestFixture::new();
 
@@ -502,6 +524,7 @@ fn test_list_for_subscription() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_cleanup_old_deliveries() {
     let fixture = TestFixture::new();
 
@@ -561,6 +584,7 @@ fn test_cleanup_old_deliveries() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_claim_pagination() {
     let fixture = TestFixture::new();
 
@@ -598,6 +622,7 @@ fn test_claim_pagination() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_retry_failed_delivery() {
     let fixture = TestFixture::new();
 
@@ -632,6 +657,7 @@ fn test_retry_failed_delivery() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_get_stats() {
     let fixture = TestFixture::new();
 
@@ -687,6 +713,7 @@ fn test_get_stats() {
 // =============================================================================
 
 #[test]
+#[serial(webhook_queue)]
 fn test_exponential_backoff_timing() {
     use chrono::{Duration, Utc};
 
@@ -788,6 +815,7 @@ fn test_exponential_backoff_timing() {
 // =============================================================================
 
 #[test]
+#[serial(webhook_queue)]
 fn test_claim_requires_all_labels() {
     let fixture = TestFixture::new();
 
@@ -849,6 +877,7 @@ fn test_claim_requires_all_labels() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_empty_target_labels_matches_broker() {
     let fixture = TestFixture::new();
 
@@ -895,6 +924,7 @@ fn test_empty_target_labels_matches_broker() {
 // =============================================================================
 
 #[test]
+#[serial(webhook_queue)]
 fn test_valid_acquired_until_stays_acquired() {
     let fixture = TestFixture::new();
 
@@ -935,6 +965,7 @@ fn test_valid_acquired_until_stays_acquired() {
 }
 
 #[test]
+#[serial(webhook_queue)]
 fn test_released_delivery_claimable_by_different_agent() {
     let fixture = TestFixture::new();
 


### PR DESCRIPTION
## Summary
`dal::webhook_deliveries::test_release_expired` flaked in the v0.5.0 Release CI
run (`assert!(released >= 1)`), while passing locally and on PR #39.

**Root cause:** `TestFixture` connects every test to one shared DB and cargo
runs tests in parallel, but the webhook-delivery queue ops are global —
`release_expired()` sweeps all expired rows and `claim_for_broker` /
`claim_for_agent` claim from the global pending pool. A concurrent webhook test
could release or steal another's rows, so the count came back 0. Product code
is correct; the test isolation wasn't.

**Fix:** serialize the webhook-delivery DAL tests with `#[serial(webhook_queue)]`
(serial_test, already a workspace dep) so they run one-at-a-time relative to
each other while still parallelising against the rest of the suite. Added the
dev-dependency + a module comment explaining the hazard.

Module verified green: 21 passed, 0 failed.