### PR TITLE
release: 0.6.0

### DIFF
--- a/.metis/backlog/bugs/BROKKR-T-0185.md
+++ b/.metis/backlog/bugs/BROKKR-T-0185.md
@@ -40,4 +40,4 @@ Correct the workspace MSRV declaration: `Cargo.toml:5` reads `rust-version = "1.
 ## Status Updates
 
 - 2026-06-09: Found during /docs-diataxis accuracy review (BROKKR-I-0015 follow-up).
-- 2026-06-09: IMPLEMENTED (uncommitted, unit tests green): `rust-version = "1.85"` in Cargo.toml; docs already updated.
+- 2026-06-09: IMPLEMENTED (uncommitted, unit tests green): `rust-version = "1.85"` in Cargo.toml; docs already updated.- 2026-06-10 (proper resolution): the original premise was WRONG — the crates were edition 2021, and `edition`/`rust-version` under `[workspace]` were dead keys (Cargo "unused manifest key"), so the 1.8→1.85 change had no effect. Fixed properly per user direction (option 3): moved both into `[workspace.package]` with edition 2024 + rust-version 1.90, members inherit via `.workspace = true`. cargo fix --edition applied (unsafe env::set_var, let-chains, 2024 fmt). Build + all units green; OpenAPI spec unchanged. Commit e53e8d8.

--- a/.metis/backlog/bugs/BROKKR-T-0186.md
+++ b/.metis/backlog/bugs/BROKKR-T-0186.md
@@ -4,15 +4,15 @@ level: task
 title: "CLI rotate agent/generator discards the new PAK — credential unrecoverable"
 short_code: "BROKKR-T-0186"
 created_at: 2026-06-10T03:03:53.125495+00:00
-updated_at: 2026-06-10T03:03:53.125495+00:00
+updated_at: 2026-06-10T11:19:05.602248+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -24,6 +24,12 @@ initiative_id: NULL
 ## Objective
 
 `brokkr-broker rotate agent --uuid <id>` and `rotate generator --uuid <id>` generate a new PAK, store only its hash, and never output the key (`crates/brokkr-broker/src/cli/commands.rs:206-250`: `let new_pak_hash = utils::pak::create_pak()?.1;`). After CLI rotation nobody possesses the credential — the entity is locked out until rotated again via the REST API. The API endpoints (`POST /api/v1/{agents,generators}/{id}/rotate-pak`) return the PAK and are unaffected.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/BROKKR-T-0189.md
+++ b/.metis/backlog/bugs/BROKKR-T-0189.md
@@ -4,15 +4,15 @@ level: task
 title: "Audit actions defined but never emitted (auth.failed, config.reloaded)"
 short_code: "BROKKR-T-0189"
 created_at: 2026-06-10T03:04:10.114868+00:00
-updated_at: 2026-06-10T03:04:10.114868+00:00
+updated_at: 2026-06-10T11:19:06.537658+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -24,6 +24,12 @@ initiative_id: NULL
 ## Objective
 
 Audit action constants exist that are never emitted: `ACTION_AUTH_FAILED` is defined and even queried by the DAL (`crates/brokkr-broker/src/dal/audit_logs.rs:278-283`) but no code path logs it; `POST /api/v1/admin/config/reload` emits no audit event despite config changes being audit-relevant. Today only `agents.rs`, `stacks.rs`, and `webhooks.rs` call `audit::log_action`. The audit-log reference previously documented these phantom events (now corrected).
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/BROKKR-T-0190.md
+++ b/.metis/backlog/bugs/BROKKR-T-0190.md
@@ -4,15 +4,15 @@ level: task
 title: "Diagnostics namespace hardcoded to 'default' — derive from deployment object"
 short_code: "BROKKR-T-0190"
 created_at: 2026-06-10T03:04:11.031061+00:00
-updated_at: 2026-06-10T03:04:11.031061+00:00
+updated_at: 2026-06-10T11:19:07.512767+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -26,6 +26,12 @@ initiative_id: NULL
 The namespace the agent searches when fulfilling an on-demand diagnostics request is the unconditional literal `"default"` (`crates/brokkr-agent/src/cli/commands.rs:387`, flowing into `collect_diagnostics()` at `diagnostics.rs:146` for pod statuses, events, and log tails). For workloads in any other namespace the label selector matches nothing and the agent submits an empty-but-successful result (`pod_statuses: []`) — no error indicates the namespace mismatch. The code comment marks it as a known TODO ("should be derived from the deployment object").
 
 Derive the namespace(s) from the deployment object's manifests (parse `metadata.namespace` from `yaml_content`), or search across namespaces by label.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/BROKKR-T-0191.md
+++ b/.metis/backlog/bugs/BROKKR-T-0191.md
@@ -4,15 +4,15 @@ level: task
 title: "Deployment health discovery label is never injected — health always 'unknown'"
 short_code: "BROKKR-T-0191"
 created_at: 2026-06-10T03:04:17.905088+00:00
-updated_at: 2026-06-10T03:04:17.905088+00:00
+updated_at: 2026-06-10T11:19:08.966529+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -26,6 +26,12 @@ initiative_id: NULL
 Deployment health discovers pods via the label selector `brokkr.io/deployment-object-id=<uuid>` across all namespaces (`crates/brokkr-agent/src/deployment_health.rs:235`), but nothing in Brokkr injects that label: the agent stamps tracking keys as **annotations** on the top-level applied objects only (`crates/brokkr-agent/src/k8s/objects.rs:80-100`), and those don't propagate to controller-created pods. Result: zero pods found ⇒ every deployment object reports `unknown` unless an operator manually labels pod templates with a UUID they can only learn after creation. Related defect found in the same code: `obj.metadata.annotations = Some(annotations)` REPLACES the manifest's own top-level annotations rather than merging.
 
 Options: inject the label into `spec.template.metadata.labels` for workload kinds during `create_k8s_objects`, or resolve pods via ownerReferences from stack-annotated objects. Fix the annotation-clobbering while in there (merge, don't replace).
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/backlog/bugs/BROKKR-T-0193.md
+++ b/.metis/backlog/bugs/BROKKR-T-0193.md
@@ -4,15 +4,15 @@ level: task
 title: "Namespace rollback deletes pre-existing namespaces on reconciliation failure"
 short_code: "BROKKR-T-0193"
 created_at: 2026-06-10T03:18:27.529625+00:00
-updated_at: 2026-06-10T03:18:27.529625+00:00
+updated_at: 2026-06-10T11:19:09.240802+00:00
 parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -26,6 +26,12 @@ initiative_id: NULL
 `reconcile_target_state` (`crates/brokkr-agent/src/k8s/api.rs:686-810`) tracks the names of every Namespace object **declared in the deployment object** and, on failure during priority apply, validation, or the main apply, calls `rollback_namespaces`, which best-effort deletes them. It never checks whether the namespace existed before this reconciliation — so a deployment object that declares a namespace which was already present (created manually or by another stack) gets that namespace **deleted on rollback**, taking everything in it with it. Deleting a namespace deletes all resources inside it; this is a data-loss-grade footgun.
 
 Fix: record whether each namespace was created by this reconciliation (e.g. check existence before apply, or compare creation timestamp/ownership annotation) and roll back only namespaces this pass actually created. Consider whether namespace rollback is wanted at all given server-side-apply idempotency.
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-agent"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aquamarine",
  "axum",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-broker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-models"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "brokkr-utils",
  "chrono",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-utils"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "config",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-wire"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "brokkr-models",
  "chrono",

--- a/charts/brokkr-agent/Chart.yaml
+++ b/charts/brokkr-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: brokkr-agent
 description: Brokkr Kubernetes cluster agent
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 # Shipwright integration (when enabled) requires Kubernetes >= 1.29
 kubeVersion: ">=1.29.0-0"
 

--- a/charts/brokkr-broker/Chart.yaml
+++ b/charts/brokkr-broker/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: brokkr-broker
 description: Brokkr control plane broker
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 
 dependencies:
   - name: postgresql

--- a/crates/brokkr-agent/Cargo.toml
+++ b/crates/brokkr-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-agent"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/brokkr-broker/Cargo.toml
+++ b/crates/brokkr-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-broker"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/brokkr-client/Cargo.toml
+++ b/crates/brokkr-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-client"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license = "Elastic-2.0"

--- a/crates/brokkr-client/spec/brokkr-v1.json
+++ b/crates/brokkr-client/spec/brokkr-v1.json
@@ -2686,7 +2686,7 @@
       "name": ""
     },
     "title": "brokkr-broker",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/crates/brokkr-models/Cargo.toml
+++ b/crates/brokkr-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-models"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/brokkr-utils/Cargo.toml
+++ b/crates/brokkr-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-utils"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/crates/brokkr-wire/Cargo.toml
+++ b/crates/brokkr-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-wire"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license = "Elastic-2.0"

--- a/openapi/brokkr-v1.json
+++ b/openapi/brokkr-v1.json
@@ -2686,7 +2686,7 @@
       "name": ""
     },
     "title": "brokkr-broker",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/sdks/python/brokkr-client/brokkr_broker_client/helpers.py
+++ b/sdks/python/brokkr-client/brokkr_broker_client/helpers.py
@@ -33,12 +33,12 @@ if TYPE_CHECKING:
 
 
 def list_telemetry_events(
-    client: "AuthenticatedClient",
+    client: AuthenticatedClient,
     stack_id: UUID,
     *,
     since: datetime.datetime | None = None,
     limit: int | None = None,
-) -> "K8SEventHistoryResponse":
+) -> K8SEventHistoryResponse:
     """Paginated kube-event history for a stack within the 6h retention window."""
     from .api.stack_telemetry import list_telemetry_events as _op
     from .types import UNSET
@@ -50,19 +50,17 @@ def list_telemetry_events(
         limit=limit if limit is not None else UNSET,
     )
     if result is None:
-        raise RuntimeError(
-            "list_telemetry_events returned None — check broker response"
-        )
+        raise RuntimeError("list_telemetry_events returned None — check broker response")
     return result
 
 
 async def list_telemetry_events_async(
-    client: "AuthenticatedClient",
+    client: AuthenticatedClient,
     stack_id: UUID,
     *,
     since: datetime.datetime | None = None,
     limit: int | None = None,
-) -> "K8SEventHistoryResponse":
+) -> K8SEventHistoryResponse:
     """Async variant of :func:`list_telemetry_events`."""
     from .api.stack_telemetry import list_telemetry_events as _op
     from .types import UNSET
@@ -74,19 +72,17 @@ async def list_telemetry_events_async(
         limit=limit if limit is not None else UNSET,
     )
     if result is None:
-        raise RuntimeError(
-            "list_telemetry_events returned None — check broker response"
-        )
+        raise RuntimeError("list_telemetry_events returned None — check broker response")
     return result
 
 
 def list_telemetry_logs(
-    client: "AuthenticatedClient",
+    client: AuthenticatedClient,
     stack_id: UUID,
     *,
     since: datetime.datetime | None = None,
     limit: int | None = None,
-) -> "PodLogHistoryResponse":
+) -> PodLogHistoryResponse:
     """Paginated pod-log history for a stack within the 6h retention window."""
     from .api.stack_telemetry import list_telemetry_logs as _op
     from .types import UNSET
@@ -103,12 +99,12 @@ def list_telemetry_logs(
 
 
 async def list_telemetry_logs_async(
-    client: "AuthenticatedClient",
+    client: AuthenticatedClient,
     stack_id: UUID,
     *,
     since: datetime.datetime | None = None,
     limit: int | None = None,
-) -> "PodLogHistoryResponse":
+) -> PodLogHistoryResponse:
     """Async variant of :func:`list_telemetry_logs`."""
     from .api.stack_telemetry import list_telemetry_logs as _op
     from .types import UNSET
@@ -124,7 +120,7 @@ async def list_telemetry_logs_async(
     return result
 
 
-def list_ws_connections(client: "AuthenticatedClient") -> "WsConnectionsResponse":
+def list_ws_connections(client: AuthenticatedClient) -> WsConnectionsResponse:
     """Admin-only snapshot of currently-connected agents on the internal WS channel.
 
     For continuous monitoring prefer scraping the
@@ -135,23 +131,19 @@ def list_ws_connections(client: "AuthenticatedClient") -> "WsConnectionsResponse
 
     result = _op.sync(client=client)
     if result is None:
-        raise RuntimeError(
-            "list_ws_connections returned None — check broker response"
-        )
+        raise RuntimeError("list_ws_connections returned None — check broker response")
     return result
 
 
 async def list_ws_connections_async(
-    client: "AuthenticatedClient",
-) -> "WsConnectionsResponse":
+    client: AuthenticatedClient,
+) -> WsConnectionsResponse:
     """Async variant of :func:`list_ws_connections`."""
     from .api.admin import list_ws_connections as _op
 
     result = await _op.asyncio(client=client)
     if result is None:
-        raise RuntimeError(
-            "list_ws_connections returned None — check broker response"
-        )
+        raise RuntimeError("list_ws_connections returned None — check broker response")
     return result
 
 

--- a/sdks/python/brokkr-client/pyproject.toml
+++ b/sdks/python/brokkr-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client-generated"
-version = "0.5.0"
+version = "0.6.0"
 description = "A client library for accessing brokkr-broker"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/python/brokkr/pyproject.toml
+++ b/sdks/python/brokkr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Ergonomic Python wrapper around the auto-generated brokkr-client-generated low-level client"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/typescript/brokkr-client/package-lock.json
+++ b/sdks/typescript/brokkr-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@colliery-io/brokkr-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@colliery-io/brokkr-client",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/sdks/typescript/brokkr-client/package.json
+++ b/sdks/typescript/brokkr-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colliery-io/brokkr-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Auto-generated TypeScript client for the Brokkr broker API",
   "license": "Elastic-2.0",
   "repository": {


### PR DESCRIPTION
## Release prep for v0.6.0

Lockstep version bump 0.5.0 → 0.6.0 across every published surface, plus the Metis ticket completions that missed the squash of #42.

### Version bumped
- Workspace crates (broker, agent, client, models, utils, wire) + `Cargo.lock`
- Helm charts (broker, agent): `version` + `appVersion`
- SDKs: Rust crate, Python wrapper (`brokkr`) + generated (`brokkr-client`), TypeScript (`@colliery-io/brokkr-client`) + lockfile

### Regenerated (drift gates green)
- `openapi/brokkr-v1.json` (+ in-crate mirror): `info.version` → 0.6.0
- Python + TypeScript generated clients (`openapi check`, `check-python`, `check-typescript` all pass locally)

### What's in 0.6.0
The squash-merged #42: doc validation + restructure, nine correctness fixes (CLI PAK rotation, config-file loading, constant-time PAK compare, full audit emission, manifest-derived diagnostics namespaces, ownerRef health attribution, namespace-scoped agents, rollback data-loss fix), and the Rust edition-2024 / MSRV-1.90 migration.

### After merge
Tag to trigger the release pipeline (build → manual approval gate → publish):
```
git tag v0.6.0 && git push origin v0.6.0
```