### PR TITLE
chore(release): bump lockstep version to 0.7.0

### DIFF
--- a/.metis/initiatives/BROKKR-I-0026/initiative.md
+++ b/.metis/initiatives/BROKKR-I-0026/initiative.md
@@ -4,7 +4,7 @@ level: initiative
 title: "Docs and CI hygiene: staleness, coverage gaps, flake hardening"
 short_code: "BROKKR-I-0026"
 created_at: 2026-06-11T11:01:39.530373+00:00
-updated_at: 2026-06-11T19:45:26.793326+00:00
+updated_at: 2026-06-11T21:29:00.157997+00:00
 parent: brokkr-environment-aware
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#initiative"
   - "#initiative"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false

--- a/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0215.md
+++ b/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0215.md
@@ -4,7 +4,7 @@ level: task
 title: "Docs: staleness sweep (binary count, versions, container tags, rustdoc tags)"
 short_code: "BROKKR-T-0215"
 created_at: 2026-06-11T11:02:08.276101+00:00
-updated_at: 2026-06-11T19:55:49.241149+00:00
+updated_at: 2026-06-11T21:08:02.661727+00:00
 parent: docs-and-ci-hygiene-staleness
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -28,6 +28,8 @@ initiative_id: BROKKR-I-0026
 ## Objective
 
 Fix every stale-claim finding from the docs sweep (excluding submission-example modernization — that is T-0216).
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0216.md
+++ b/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0216.md
@@ -4,7 +4,7 @@ level: task
 title: "Docs: modernize submission examples onto the yaml/CLI on-ramp"
 short_code: "BROKKR-T-0216"
 created_at: 2026-06-11T11:02:08.324875+00:00
-updated_at: 2026-06-11T20:00:35.714313+00:00
+updated_at: 2026-06-11T21:08:02.761123+00:00
 parent: docs-and-ci-hygiene-staleness
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -28,6 +28,8 @@ initiative_id: BROKKR-I-0026
 ## Objective
 
 The tutorials and quick start still teach the pre-I-0021 submission path — hand-escaped `yaml_content` JSON — while `how-to/managing-stacks.md` now labels raw `application/yaml` "recommended" and the CLI exists for exactly the CI use case. Misleads by omission; modernize without breaking each page's Diátaxis lane.
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0217.md
+++ b/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0217.md
@@ -4,7 +4,7 @@ level: task
 title: "CI: add brokkr-wire, brokkr-cli, brokkr-client to the unit-test matrix"
 short_code: "BROKKR-T-0217"
 created_at: 2026-06-11T11:02:08.378231+00:00
-updated_at: 2026-06-11T19:48:29.492021+00:00
+updated_at: 2026-06-11T21:08:02.808431+00:00
 parent: docs-and-ci-hygiene-staleness
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -28,6 +28,8 @@ initiative_id: BROKKR-I-0026
 ## Objective
 
 `unit_tests.yml:9` matrix is `[brokkr-agent, brokkr-broker, brokkr-models, brokkr-utils]`, but `.angreal/task_tests.py:14` also lists `brokkr-wire` as a unit-test crate, and `brokkr-cli` (16 tests) and `brokkr-client` (14+ tests) have suites that run nowhere in CI — PR, nightly, or release gates.
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0218.md
+++ b/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0218.md
@@ -4,7 +4,7 @@ level: task
 title: "CI: flake hardening and efficiency (retries, registry auth, cache keys)"
 short_code: "BROKKR-T-0218"
 created_at: 2026-06-11T11:02:08.427026+00:00
-updated_at: 2026-06-11T19:53:03.546611+00:00
+updated_at: 2026-06-11T21:08:02.855059+00:00
 parent: docs-and-ci-hygiene-staleness
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -28,6 +28,8 @@ initiative_id: BROKKR-I-0026
 ## Objective
 
 Harden the two flake classes that bit us this week (Docker Hub pull timeout during `imagetools create`; artifact-upload `Failed to CreateArtifact: ETIMEDOUT`) and stop paying for CI work nobody uses.
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0219.md
+++ b/.metis/initiatives/BROKKR-I-0026/tasks/BROKKR-T-0219.md
@@ -4,7 +4,7 @@ level: task
 title: "Crates: workspace-inherited license/repository metadata + descriptions"
 short_code: "BROKKR-T-0219"
 created_at: 2026-06-11T11:02:08.479488+00:00
-updated_at: 2026-06-11T19:46:02.656776+00:00
+updated_at: 2026-06-11T21:08:02.901900+00:00
 parent: docs-and-ci-hygiene-staleness
 blocked_by: []
 archived: false
@@ -12,7 +12,7 @@ archived: false
 tags:
   - "#task"
   - "#task"
-  - "#phase/active"
+  - "#phase/completed"
 
 
 exit_criteria_met: false
@@ -28,6 +28,8 @@ initiative_id: BROKKR-I-0026
 ## Objective
 
 `brokkr-agent`, `brokkr-broker`, `brokkr-models`, `brokkr-utils` have no `license`, `description`, or `repository` in Cargo.toml (brokkr-cli, brokkr-client, brokkr-wire have them). Add via workspace inheritance so future crates get them for free.
+
+## Acceptance Criteria
 
 ## Acceptance Criteria
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-agent"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aquamarine",
  "axum",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-broker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "brokkr-client",
  "clap",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-models"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "brokkr-utils",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-utils"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "config",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-wire"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "brokkr-models",
  "chrono",

--- a/charts/brokkr-agent/Chart.yaml
+++ b/charts/brokkr-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: brokkr-agent
 description: Brokkr Kubernetes cluster agent
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 # Shipwright integration (when enabled) requires Kubernetes >= 1.29
 kubeVersion: ">=1.29.0-0"
 

--- a/charts/brokkr-broker/Chart.yaml
+++ b/charts/brokkr-broker/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: brokkr-broker
 description: Brokkr control plane broker
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 
 dependencies:
   - name: postgresql

--- a/crates/brokkr-agent/Cargo.toml
+++ b/crates/brokkr-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-agent"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-broker/Cargo.toml
+++ b/crates/brokkr-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-broker"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-cli/Cargo.toml
+++ b/crates/brokkr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Command-line client for the Brokkr control plane: apply a folder of Kubernetes manifests as a stack's desired state."

--- a/crates/brokkr-client/Cargo.toml
+++ b/crates/brokkr-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-client"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-client/spec/brokkr-v1.json
+++ b/crates/brokkr-client/spec/brokkr-v1.json
@@ -2687,7 +2687,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/crates/brokkr-models/Cargo.toml
+++ b/crates/brokkr-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-models"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-utils/Cargo.toml
+++ b/crates/brokkr-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-utils"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-wire/Cargo.toml
+++ b/crates/brokkr-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-wire"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/openapi/brokkr-v1.json
+++ b/openapi/brokkr-v1.json
@@ -2687,7 +2687,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/sdks/python/brokkr-client/pyproject.toml
+++ b/sdks/python/brokkr-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client-generated"
-version = "0.6.0"
+version = "0.7.0"
 description = "A client library for accessing brokkr-broker"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/python/brokkr/pyproject.toml
+++ b/sdks/python/brokkr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client"
-version = "0.6.0"
+version = "0.7.0"
 description = "Ergonomic Python wrapper around the auto-generated brokkr-client-generated low-level client"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/typescript/brokkr-client/package.json
+++ b/sdks/typescript/brokkr-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colliery-io/brokkr-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Auto-generated TypeScript client for the Brokkr broker API",
   "license": "Elastic-2.0",
   "repository": {


### PR DESCRIPTION
Bumps every version-of-record file to **0.7.0** in lockstep, per the project's [lockstep versioning](https://github.com/colliery-io/brokkr) policy (the git tag drives the release; source files are bumped ahead of tagging).

## Bumped (0.6.0 → 0.7.0)
- **7 workspace crates**: brokkr-broker, brokkr-agent, brokkr-models, brokkr-utils, brokkr-wire, brokkr-client, brokkr-cli
- **Both Helm charts**: `version` + `appVersion` (brokkr-broker, brokkr-agent)
- **All three SDKs**: Rust `brokkr-client`, Python `brokkr` + `brokkr-client`, TypeScript `@colliery-io/brokkr-client`
- **Cargo.lock** workspace members
- **Regenerated** `openapi/brokkr-v1.json` (+ Rust-client mirror) — `info.version` → 0.7.0

## Verification
- `cargo check --workspace` clean; Cargo.lock shows all brokkr crates at 0.7.0
- `angreal openapi check` / `check-python` / `check-typescript` all pass (no drift)

Also includes a metis commit marking I-0026 and its five tasks completed (the closeout of the pre-0.7.0 quality sweep, I-0022 → I-0026).