### PR TITLE
docs(metis): I-0027 → design + decompose into 3 tasks

### DIFF
--- a/.metis/initiatives/BROKKR-I-0027/initiative.md
+++ b/.metis/initiatives/BROKKR-I-0027/initiative.md
@@ -4,14 +4,14 @@ level: initiative
 title: "Agent Fleet Legibility"
 short_code: "BROKKR-I-0027"
 created_at: 2026-06-12T21:20:39.756079+00:00
-updated_at: 2026-06-12T21:20:39.756079+00:00
+updated_at: 2026-06-12T21:39:43.510414+00:00
 parent: brokkr-environment-aware
 blocked_by: []
 archived: false
 
 tags:
   - "#initiative"
-  - "#phase/discovery"
+  - "#phase/design"
 
 
 exit_criteria_met: false

--- a/.metis/initiatives/BROKKR-I-0027/tasks/BROKKR-T-0226.md
+++ b/.metis/initiatives/BROKKR-I-0027/tasks/BROKKR-T-0226.md
@@ -1,0 +1,85 @@
+---
+id: slice-1-get-api-v1-fleet-broker
+level: task
+title: "Slice 1: GET /api/v1/fleet broker-computed fleet surface + gauge-staleness fix"
+short_code: "BROKKR-T-0226"
+created_at: 2026-06-12T21:39:43.651317+00:00
+updated_at: 2026-06-12T21:39:43.651317+00:00
+parent: agent-fleet-legibility
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: BROKKR-I-0027
+---
+
+# Slice 1: GET /api/v1/fleet broker-computed fleet surface + gauge-staleness fix
+
+## Parent Initiative
+
+[[BROKKR-I-0027]]
+
+## Objective
+
+Ship the broker-computed fleet legibility surface: a pull endpoint that returns,
+per agent, the measured signals defined in the I-0027 v1 fleet record — using
+only data the broker already has (no migrations, no agent changes). Also fold in
+the pre-existing Prometheus gauge-staleness fix.
+
+## Acceptance Criteria
+
+- [ ] `GET /api/v1/fleet` returns an array of per-agent records with measured
+      values (no verdicts): `agent_id`, `name`, `status`, `ws_connected`,
+      `connected_since`, `last_heartbeat`, `heartbeat_age_seconds`,
+      `pending_object_count`, `pending_work_orders`, `claimed_work_orders`,
+      `last_event_at`, `seconds_since_last_event`, `health_failing`,
+      `health_degraded`. (`k8s_reachable` is Slice 2 — omit here.)
+- [ ] Per-agent detail view returns the same record plus the recent-events feed
+      (latest N `agent_events`, newest first). Decide: new
+      `GET /api/v1/agents/{id}/fleet-status` vs extending an existing handler.
+- [ ] All fields computed from existing data on read:
+      - `ws_connected`/`connected_since` from the WS `ConnectionRegistry`
+        (`is_connected` / snapshot).
+      - `heartbeat_age_seconds` = now − `agents.last_heartbeat` (computed on read,
+        not the gauge).
+      - `pending_object_count` = target-state objects for the agent with no
+        `agent_event` yet (reuse `get_target_state_for_agent(.., include_deployed=false)`).
+      - `pending_work_orders` (list_pending_for_agent count) + `claimed_work_orders`
+        (`work_orders WHERE status='CLAIMED' AND claimed_by=agent`).
+      - `last_event_at` = `max(agent_events.created_at)` per agent;
+        `seconds_since_last_event` derived.
+      - `health_failing`/`health_degraded` = `deployment_health` counts by status
+        for the agent.
+- [ ] Efficiency: the rollup must not be N+1 per agent — aggregate counts in
+      bounded queries (e.g. grouped counts), not a per-agent query fan-out.
+- [ ] **Gauge-staleness fix (folded in):** add a background task that periodically
+      refreshes `brokkr_active_agents` and `brokkr_agent_heartbeat_age_seconds`
+      from the DB, so they are correct independent of who calls `GET /agents`
+      (today they only refresh inside the `list_agents` handler — agents.rs:113/117).
+- [ ] OpenAPI updated + spec/SDKs regenerated (`angreal openapi export` + gen);
+      drift checks pass.
+- [ ] Reference docs updated (new endpoint in the API reference; mention in
+      monitoring/agent-fleet docs).
+- [ ] Tests: integration test asserts the rollup returns the expected fields and
+      that pending/backpressure/activity values reflect seeded state; unit test
+      for the gauge-refresh task.
+
+## Implementation Notes
+
+- Authz: same RBAC as `GET /agents` (admin/operator visibility) — confirm the
+  generator/agent roles cannot read the whole fleet.
+- Auth-cache / DAL: route DB access through the existing DAL `conn()` helper.
+- Keep it read-only and verdict-free — measured values only (I-0027 philosophy).
+- Watch cardinality on any new metrics (per-agent labels stay off hot-path
+  counters, per the WS-metrics convention in metrics.rs).
+
+## Status Updates
+
+*To be added during implementation*

--- a/.metis/initiatives/BROKKR-I-0027/tasks/BROKKR-T-0227.md
+++ b/.metis/initiatives/BROKKR-I-0027/tasks/BROKKR-T-0227.md
@@ -1,0 +1,60 @@
+---
+id: slice-2-agent-reported-k8s
+level: task
+title: "Slice 2: agent-reported K8s connectivity signal in /fleet"
+short_code: "BROKKR-T-0227"
+created_at: 2026-06-12T21:39:43.724081+00:00
+updated_at: 2026-06-12T21:39:43.724081+00:00
+parent: agent-fleet-legibility
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: BROKKR-I-0027
+---
+
+# Slice 2: agent-reported K8s connectivity signal in /fleet
+
+## Parent Initiative
+
+[[BROKKR-I-0027]]
+
+## Objective
+
+Add the one fleet signal the broker cannot compute on its own: whether each agent
+can reach its own Kubernetes API. The agent self-reports it; the broker stores the
+latest per agent and surfaces it in the fleet record. Depends on Slice 1
+([[BROKKR-T-0226]]) for the surface.
+
+## Acceptance Criteria
+
+- [ ] Agent heartbeat payload (or a dedicated report) carries `k8s_reachable: bool`
+      and optional `k8s_api_latency_ms: int`. Both optional — agents that cannot
+      determine it omit them (graceful degradation).
+- [ ] Broker stores the latest snapshot per agent. Decide storage: nullable
+      columns on `agents` vs a small `agent_operational_status` table (1 row/agent).
+      Migration with verified up/down (`angreal models migrations`).
+- [ ] Agent side: collect reachability (e.g. a lightweight K8s API healthz/version
+      probe on the heartbeat cycle) and include it in the heartbeat.
+- [ ] `GET /api/v1/fleet` and the per-agent detail include `k8s_reachable`
+      (+ latency if present); `null`/absent when never reported.
+- [ ] OpenAPI + SDKs regenerated; drift checks pass. Reference docs updated.
+- [ ] Tests: integration test — an agent reporting `k8s_reachable=false` surfaces
+      in `/fleet`; an agent that never reports shows null without breaking the
+      rollup.
+
+## Implementation Notes
+
+- Keep "trust the agent" (I-0027 non-goal: don't validate agent-reported data).
+- This is deliberately standalone/small — it should not block Slice 1 shipping.
+
+## Status Updates
+
+*To be added during implementation*

--- a/.metis/initiatives/BROKKR-I-0027/tasks/BROKKR-T-0228.md
+++ b/.metis/initiatives/BROKKR-I-0027/tasks/BROKKR-T-0228.md
@@ -1,0 +1,60 @@
+---
+id: follow-up-agent-events-retention
+level: task
+title: "Follow-up: agent_events retention/eviction policy (unbounded growth)"
+short_code: "BROKKR-T-0228"
+created_at: 2026-06-12T21:39:43.790408+00:00
+updated_at: 2026-06-12T21:39:43.790408+00:00
+parent: agent-fleet-legibility
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/todo"
+  - "#task"
+  - "#phase/todo"
+
+
+exit_criteria_met: false
+initiative_id: BROKKR-I-0027
+---
+
+# Follow-up: agent_events retention/eviction policy (unbounded growth)
+
+## Parent Initiative
+
+[[BROKKR-I-0027]]
+
+## Objective
+
+`agent_events` currently has no eviction — rows accumulate forever (soft-deleted
+only on agent-delete cascade). Surfaced while scoping the fleet activity feed
+(I-0027). Orthogonal to legibility but a real operational liability at fleet
+scale. Add a retention policy.
+
+## Backlog Item Details
+
+### Type
+- [x] Tech Debt
+
+## Acceptance Criteria
+
+- [ ] A retention policy for `agent_events` (configurable window; choose a sane
+      default — note this is operator history, so likely a longer window than the
+      6h telemetry ceiling, e.g. days/weeks). Decide hard-delete vs soft-delete.
+- [ ] A background eviction task removes events older than the window (mirror the
+      existing retention worker / diagnostic-cleanup patterns).
+- [ ] Config key + default documented; `0`/unset disables (keep current behavior).
+- [ ] Test: events older than the window are evicted; recent ones retained; the
+      fleet activity feed (T-0226) still returns the latest N.
+
+## Implementation Notes
+
+- Reference the existing telemetry retention worker (WS 6h ceiling) and the
+  diagnostic-cleanup task as patterns.
+- Coordinate the default window with the fleet activity feed's "recent N" needs.
+
+## Status Updates
+
+*To be added during implementation*


### PR DESCRIPTION
Transitions Agent Fleet Legibility (I-0027) discovery → design and decomposes it into the agreed slices:
- **T-0226 (Slice 1)** — `GET /api/v1/fleet` broker-computed fleet surface (all v1 measured signals from existing data, no migrations/no agent changes) + the folded-in Prometheus gauge-staleness fix.
- **T-0227 (Slice 2)** — agent-reported K8s connectivity signal (heartbeat payload + storage + surface), standalone, depends on Slice 1.
- **T-0228 (follow-up)** — agent_events retention/eviction (the table grows unbounded today).

Each task fully written (objective, acceptance criteria grounded in real file/DAL references, implementation notes). Metis-only.