### PR TITLE
fix(angreal): propagate test-task exit status (T-0027)

### DIFF
--- a/.angreal/task_tests.py
+++ b/.angreal/task_tests.py
@@ -95,14 +95,15 @@ CRATES = get_crates()
 def unit_tests(crate_name: str, test_filter: str = ""):
     """Run unit tests for a specific crate."""
     return_codes = []
-    rc = None
+    rc = 0
     if crate_name == "all":
         for crate in CRATES["unit_tests"]:
-            return_code = run_unit_tests(crate, test_filter)
-            return_codes.append((crate,return_code))
-        if any(code != 0 for _, code in return_codes):
-            rc =   max(code for _, code in return_codes)
-            print(f"Unit tests failed for {crate} with return code {rc}")
+            return_codes.append((crate, run_unit_tests(crate, test_filter)))
+        failed = [(c, code) for c, code in return_codes if code != 0]
+        if failed:
+            for c, code in failed:
+                print(f"Unit tests failed for {c} with return code {code}")
+            rc = max(code for _, code in failed)
     else:
         rc = run_unit_tests(crate_name, test_filter)
 
@@ -123,16 +124,17 @@ def integration_tests(crate_name: str, test_filter: str = "", skip_docker: bool 
     print("Sleeping for 30 seconds, waiting for services to stabilize - get some coffee")
     time.sleep(30)
 
-    rc = None
+    rc = 0
     return_codes = []
     try:
         if crate_name == "all":
             for crate in CRATES["integration_tests"]:
-                return_code = run_integration_tests(crate, test_filter)
-                return_codes.append((crate,return_code))
-            if any(code != 0 for _, code in return_codes):
-                rc =   max(code for _, code in return_codes)
-                print(f"Integration tests failed for {crate} with return code {rc}")
+                return_codes.append((crate, run_integration_tests(crate, test_filter)))
+            failed = [(c, code) for c, code in return_codes if code != 0]
+            if failed:
+                for c, code in failed:
+                    print(f"Integration tests failed for {c} with return code {code}")
+                rc = max(code for _, code in failed)
         else:
             rc = run_integration_tests(crate_name, test_filter)
         if not skip_docker:
@@ -141,7 +143,10 @@ def integration_tests(crate_name: str, test_filter: str = "", skip_docker: bool 
         if not skip_docker:
             docker_down()
             docker_clean()
-        return rc
+    # Return OUTSIDE the finally: a `return` in `finally` swallows any exception
+    # from the try and masks it as exit 0. Cleanup belongs in finally; the exit
+    # status must reflect real failures (BROKKR-T-0027).
+    return rc
 
 
 def _sdk_contract_env():
@@ -355,7 +360,9 @@ def sdk_contract_tests(language: str, skip_docker: bool = False):
         if not skip_docker:
             docker_down()
             docker_clean()
-        return rc
+    # Return OUTSIDE the finally (BROKKR-T-0027): a `return` in `finally`
+    # swallows exceptions from the try and masks them as exit 0.
+    return rc
 
 
 @test()
@@ -379,7 +386,7 @@ def e2e_tests(skip_docker: bool = False, scenario: str = ""):
     print("Sleeping for 30 seconds, waiting for services to stabilize - get some coffee")
     time.sleep(30)
 
-    rc = None
+    rc = 0
     try:
         rc = run_e2e_tests(scenario=scenario)
         if not skip_docker:
@@ -388,4 +395,6 @@ def e2e_tests(skip_docker: bool = False, scenario: str = ""):
         if not skip_docker:
             docker_down()
             docker_clean()
-        return rc
+    # Return OUTSIDE the finally (BROKKR-T-0027): a `return` in `finally`
+    # swallows exceptions from the try and masks them as exit 0.
+    return rc

--- a/.metis/.index-dirty
+++ b/.metis/.index-dirty
@@ -1,0 +1,1 @@
+/Users/dstorey/Desktop/brokkr/.angreal/task_tests.py

--- a/.metis/backlog/bugs/BROKKR-T-0027.md
+++ b/.metis/backlog/bugs/BROKKR-T-0027.md
@@ -4,20 +4,19 @@ level: task
 title: "Angreal Task Exit Status"
 short_code: "BROKKR-T-0027"
 created_at: 2025-10-23T01:46:25.523842+00:00
-updated_at: 2025-10-23T01:46:25.523842+00:00
-parent:
+updated_at: 2026-06-13T15:47:11.397599+00:00
+parent: 
 blocked_by: []
 archived: false
 
 tags:
   - "#task"
-  - "#phase/backlog"
   - "#bug"
+  - "#bug"
+  - "#phase/completed"
 
 
-  - "#bug"
 exit_criteria_met: false
-strategy_id: NULL
 initiative_id: NULL
 ---
 
@@ -68,6 +67,12 @@ Fix angreal exit status codes to ensure that CI/CD pipelines appropriately “go
 - **Current Problems**: {What's difficult/slow/buggy now}
 - **Benefits of Fixing**: {What improves after refactoring}
 - **Risk Assessment**: {Risks of not addressing this}
+
+## Acceptance Criteria
+
+## Acceptance Criteria
+
+## Acceptance Criteria
 
 ## Acceptance Criteria **\[REQUIRED\]**
 
@@ -156,3 +161,23 @@ None - this is a standalone bug fix
 ## Status Updates **\[REQUIRED\]**
 
 *To be added during implementation*
+## Status Updates
+
+- 2026-06-13: Root cause = `return` inside `finally` in .angreal/task_tests.py
+  (integration_tests, sdk_contract_tests, e2e_tests). A return in finally
+  swallows any exception raised in the try and returns `rc` (default None →
+  angreal exit 0), so a setup/infra error or any Python-level failure during a
+  test run silently exits green. (Plain cargo-test failures already propagate via
+  rc.) Fix: cleanup stays in finally; the `return rc` moves out to function
+  scope so exceptions propagate (angreal exit 56) and rc is returned on failure.
+  Also default rc to 0 and fix the leaked loop-variable in the failure prints.
+
+- 2026-06-13: FIXED + verified. .angreal/task_tests.py: moved `return rc` out of
+  the finally blocks in integration_tests / sdk_contract_tests / e2e_tests
+  (cleanup stays in finally); defaulted rc to 0; fixed the leaked loop-variable
+  in the failure prints (unit + integration). Verified: `angreal tests unit
+  nonexistent-crate` -> exit 101; `angreal tests integration nonexistent-crate
+  --skip-docker` -> exit 101; passing run -> exit 0. py_compile OK; a scan
+  confirms no `return` remains inside any `finally`. The exception-swallowing
+  path is closed (demonstrated: old pattern returns None on a raised exception,
+  new pattern propagates it).


### PR DESCRIPTION
**Bug:** the test runner tasks (`integration_tests`, `sdk_contract_tests`, `e2e_tests`) had `return rc` **inside a `finally` block**. A `return` in `finally` swallows any exception raised in the `try` and returns `rc` (default `None` → angreal exit `0`) — so a setup/infra error or any Python-level failure during a test run silently exited **green**, letting CI pass on a broken run. (Plain cargo-test failures already propagated via `rc`; this closes the exception gap.)

**Fix:**
- Move `return rc` out of `finally` (cleanup stays in `finally`) so exceptions propagate (angreal exit 56) and `rc` is returned on failure.
- Default `rc` to 0; fix the leaked loop-variable in the failure prints (the "all" paths now name each failing crate).

**Verified locally:**
- `angreal tests unit nonexistent-crate` → exit **101**
- `angreal tests integration nonexistent-crate --skip-docker` → exit **101**
- a passing run → exit **0**
- `py_compile` OK; a scan confirms **no `return` remains inside any `finally`**
- demonstrated the semantics: the old pattern returns `None` on a raised exception (masked), the new pattern propagates it

Closes BROKKR-T-0027.