### PR TITLE
fix(test): de-flake test_legacy_xor_decryption + document legacy-format ambiguity

### DIFF
--- a/crates/brokkr-broker/src/utils/encryption.rs
+++ b/crates/brokkr-broker/src/utils/encryption.rs
@@ -409,9 +409,14 @@ mod tests {
         let key = EncryptionKey::generate();
         let plaintext = b"legacy data";
 
-        // Manually create legacy XOR encrypted data
-        let mut nonce = [0u8; LEGACY_XOR_NONCE_SIZE];
-        rand::thread_rng().fill_bytes(&mut nonce);
+        // Manually create legacy XOR encrypted data. The nonce is deterministic
+        // and its first byte deliberately avoids the version markers (0x00 =
+        // legacy, 0x01 = AES-GCM): decrypt() routes a *headerless* legacy blob on
+        // data[0], so a nonce starting with 0x00/0x01 would be mis-routed. A
+        // random nonce here made this test flaky (~0.78%, when nonce[0] hit a
+        // marker). The legacy-format ambiguity itself is documented in
+        // docs/src/explanation/security-model.md.
+        let nonce = [0x42u8; LEGACY_XOR_NONCE_SIZE];
 
         let mut hasher = Sha256::new();
         hasher.update(key.key);

--- a/docs/src/explanation/security-model.md
+++ b/docs/src/explanation/security-model.md
@@ -248,6 +248,12 @@ The current version byte (`0x01`) indicates AES-256-GCM encryption. The 12-byte 
 
 The encryption key is configured via the `BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY` environment variable as a 64-character hexadecimal string (representing 32 bytes). If no key is configured, the broker generates a random key at startup and logs a warning. Production deployments should always configure an explicit key to ensure encrypted data survives broker restarts.
 
+#### Legacy format and its inherent ambiguity (read-only)
+
+Data written before the versioned format is a **headerless** `nonce (16 bytes) || ciphertext` XOR blob, supported **read-only** for one-time migration (a leading version byte `0x00` also routes to this path). Because a headerless blob has no version header, the decryptor falls back to the legacy path whenever the first byte is not a known version marker.
+
+This leaves a small, inherent ambiguity: a legacy blob whose nonce happens to begin with `0x00` (legacy marker) or `0x01` (AES-GCM marker) is mis-routed and fails to decrypt. The window is tiny — roughly `2/256` (~0.78%) of legacy blobs — and is **bounded entirely to the read-only migration path**. It cannot affect new data: AES-256-GCM ciphertext always carries the `0x01` version byte and is dispatched unambiguously. The ambiguity is not fixable without a format change (headerless data is inherently undistinguishable from versioned data in that one byte), so the resolution is operational: let the migration re-encrypt legacy values into the versioned (`0x01`) format, after which the ambiguity no longer applies.
+
 ### PAK Rotation
 
 PAK rotation replaces an entity's authentication credential without disrupting its identity or permissions. The `POST /api/v1/agents/{id}/rotate-pak` endpoint (and similar endpoints for generators) generates a new PAK and invalidates the previous one atomically.


### PR DESCRIPTION
Found while watching main CI: the `unit_tests` red on `1465052` was a single flaky test (`test_legacy_xor_decryption`), which then passed on the next identical-code commit.

**Root cause:** the test builds a *headerless* legacy XOR blob (`nonce(16) || ciphertext`) with a **random** nonce, then calls `decrypt()`. `decrypt()` dispatches a headerless blob on `data[0]`; when the random `nonce[0]` hit a version marker (`0x00` legacy / `0x01` AES-GCM) it mis-routed → ~0.78% failure.

**Fix #1:** deterministic nonce (`0x42…`) whose first byte avoids the markers — exercises the headerless-legacy path reliably.
**#2 (documented):** the inherent legacy-format ambiguity is now written up in `docs/explanation/security-model.md` — bounded to the read-only migration path, can't affect versioned data, resolved by re-encrypting legacy values.

Verified: build + clippy clean; test passes deterministically (3/3 locally). Extra relevant now that T-0027 makes test failures reliably turn CI red.