### PR TITLE
chore(release): bump lockstep version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-agent"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aquamarine",
  "axum",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-broker"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "brokkr-client",
  "clap",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-models"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "brokkr-utils",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-utils"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "config",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-wire"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "brokkr-models",
  "chrono",

--- a/charts/brokkr-agent/Chart.yaml
+++ b/charts/brokkr-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: brokkr-agent
 description: Brokkr Kubernetes cluster agent
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.8.0
+appVersion: "0.8.0"
 # Shipwright integration (when enabled) requires Kubernetes >= 1.29
 kubeVersion: ">=1.29.0-0"
 

--- a/charts/brokkr-broker/Chart.yaml
+++ b/charts/brokkr-broker/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: brokkr-broker
 description: Brokkr control plane broker
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.8.0
+appVersion: "0.8.0"
 
 dependencies:
   - name: postgresql

--- a/crates/brokkr-agent/Cargo.toml
+++ b/crates/brokkr-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-agent"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-broker/Cargo.toml
+++ b/crates/brokkr-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-broker"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-cli/Cargo.toml
+++ b/crates/brokkr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Command-line client for the Brokkr control plane: apply a folder of Kubernetes manifests as a stack's desired state."

--- a/crates/brokkr-client/Cargo.toml
+++ b/crates/brokkr-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-client"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-client/spec/brokkr-v1.json
+++ b/crates/brokkr-client/spec/brokkr-v1.json
@@ -2842,7 +2842,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/crates/brokkr-models/Cargo.toml
+++ b/crates/brokkr-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-models"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-utils/Cargo.toml
+++ b/crates/brokkr-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-utils"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-wire/Cargo.toml
+++ b/crates/brokkr-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-wire"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/openapi/brokkr-v1.json
+++ b/openapi/brokkr-v1.json
@@ -2842,7 +2842,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/sdks/python/brokkr-client/pyproject.toml
+++ b/sdks/python/brokkr-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client-generated"
-version = "0.7.0"
+version = "0.8.0"
 description = "A client library for accessing brokkr-broker"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/python/brokkr/pyproject.toml
+++ b/sdks/python/brokkr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client"
-version = "0.7.0"
+version = "0.8.0"
 description = "Ergonomic Python wrapper around the auto-generated brokkr-client-generated low-level client"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/typescript/brokkr-client/package.json
+++ b/sdks/typescript/brokkr-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colliery-io/brokkr-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Auto-generated TypeScript client for the Brokkr broker API",
   "license": "Elastic-2.0",
   "repository": {


### PR DESCRIPTION
## What

Lockstep version bump **0.7.0 → 0.8.0** ahead of tagging `v0.8.0`.

## Why 0.8.0 (minor, not 0.7.1 patch)

Everything accumulated on `main` since the `v0.7.0` tag is **additive and backward-compatible new functionality**, which is a minor bump under semver:

- New REST surface: `GET /api/v1/fleet`, `GET /api/v1/fleet/{id}`, `GET /api/v1/fleet/live` (WS stream)
- New WS frame `WsMessage::FleetUpdate` (additive, `#[serde(default)]`)
- New DB migration `20_agent_k8s_connectivity` (nullable agent columns)
- Agent k8s-connectivity heartbeat reporting + fleet-sweep / agent_events-retention background tasks
- New config keys + env var
- Regenerated OpenAPI spec and all three SDKs (fleet endpoints/models)

Plus fixes: e2e reconcile (#53), CI exit-status hole (#68), and three flake/tooling fixes (#70/#71/#72).

## Files bumped (lockstep)

- 7 crate `Cargo.toml`s (literal `version`)
- 2 Helm `Chart.yaml` (`version` + `appVersion`)
- 3 SDK manifests (Python ×2, TypeScript)
- OpenAPI `info.version` (regenerated; mirrored to client spec)
- `Cargo.lock`

## Verification

- `angreal openapi check` ✅ — spec up to date
- `angreal openapi check-python` ✅ — Python SDK matches spec
- `angreal openapi check-typescript` ✅ — TS schema matches spec
- `verify-version` in `release.yml` will assert tag == crate versions on tag

No code changes — version strings + regenerated lock/spec only.