### PR TITLE
fix(broker): reconcile OpenAPI auth annotations with enforcement + graceful config-reload (T-0236)

### DIFF
--- a/crates/brokkr-broker/src/api/v1/admin.rs
+++ b/crates/brokkr-broker/src/api/v1/admin.rs
@@ -206,6 +206,7 @@ pub async fn list_ws_connections(
         (status = 200, description = "Configuration reloaded successfully", body = ConfigReloadResponse),
         (status = 401, description = "Missing or invalid authentication", body = ErrorResponse),
         (status = 403, description = "Not authorized (admin only)", body = ErrorResponse),
+        (status = 503, description = "Configuration hot-reload is not enabled on this broker", body = ErrorResponse),
         (status = 500, description = "Failed to reload configuration", body = ErrorResponse)
     ),
     security(
@@ -214,7 +215,10 @@ pub async fn list_ws_connections(
 )]
 async fn reload_config(
     Extension(auth): Extension<AuthPayload>,
-    Extension(config): Extension<ReloadableConfig>,
+    // Optional so the auth check below runs first: when hot-reload is disabled the
+    // ReloadableConfig extension is not layered (see api/v1/mod.rs). Extracting it as
+    // a required Extension would 500 before the admin check; this returns a clean 503.
+    config: Option<Extension<ReloadableConfig>>,
 ) -> Result<impl IntoResponse, ApiError> {
     if !auth.admin {
         warn!("Non-admin attempted to reload configuration");
@@ -223,6 +227,14 @@ async fn reload_config(
             "admin access required",
         ));
     }
+
+    let Extension(config) = config.ok_or_else(|| {
+        warn!("Configuration reload requested but hot-reload is not enabled");
+        ApiError::service_unavailable(
+            "config_reload_disabled",
+            "configuration hot-reload is not enabled on this broker",
+        )
+    })?;
 
     info!("Admin initiated configuration reload");
 

--- a/crates/brokkr-broker/src/api/v1/agent_events.rs
+++ b/crates/brokkr-broker/src/api/v1/agent_events.rs
@@ -37,8 +37,6 @@ pub fn routes() -> Router<DAL> {
     tag = "agent-events",
     security(
         ("admin_pak" = []),
-        ("agent_pak" = []),
-        ("generator_pak" = []),
     )
 )]
 async fn list_agent_events(
@@ -76,8 +74,6 @@ async fn list_agent_events(
     tag = "agent-events",
     security(
         ("admin_pak" = []),
-        ("agent_pak" = []),
-        ("generator_pak" = []),
     )
 )]
 async fn get_agent_event(

--- a/crates/brokkr-broker/src/api/v1/agents.rs
+++ b/crates/brokkr-broker/src/api/v1/agents.rs
@@ -252,7 +252,7 @@ async fn get_agent(
         (status = 404, description = "Agent not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     ),
-    security(("admin_pak" = []))
+    security(("admin_pak" = []), ("agent_pak" = []))
 )]
 async fn search_agent(
     State(dal): State<DAL>,

--- a/crates/brokkr-broker/src/api/v1/error.rs
+++ b/crates/brokkr-broker/src/api/v1/error.rs
@@ -96,6 +96,10 @@ impl ApiError {
     pub fn internal(message: impl Into<String>) -> Self {
         Self::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
     }
+
+    pub fn service_unavailable(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::SERVICE_UNAVAILABLE, code, message)
+    }
 }
 
 impl IntoResponse for ApiError {

--- a/crates/brokkr-client/spec/brokkr-v1.json
+++ b/crates/brokkr-client/spec/brokkr-v1.json
@@ -3050,6 +3050,16 @@
               }
             },
             "description": "Failed to reload configuration"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Configuration hot-reload is not enabled on this broker"
           }
         },
         "security": [
@@ -3129,12 +3139,6 @@
         "security": [
           {
             "admin_pak": []
-          },
-          {
-            "agent_pak": []
-          },
-          {
-            "generator_pak": []
           }
         ],
         "tags": [
@@ -3192,12 +3196,6 @@
         "security": [
           {
             "admin_pak": []
-          },
-          {
-            "agent_pak": []
-          },
-          {
-            "generator_pak": []
           }
         ],
         "tags": [
@@ -3384,6 +3382,9 @@
         "security": [
           {
             "admin_pak": []
+          },
+          {
+            "agent_pak": []
           }
         ],
         "tags": [

--- a/crates/brokkr-models/src/models/agents.rs
+++ b/crates/brokkr-models/src/models/agents.rs
@@ -22,6 +22,9 @@
 //! - `last_heartbeat`: TIMESTAMP, last time the agent sent a heartbeat
 //! - `status`: VARCHAR(50), current status of the agent
 //! - `pak_hash`: VARCHAR(255), hash of the agent's PAK (Pre-shared Authentication Key)
+//! - `k8s_reachable`: BOOLEAN, nullable; agent's self-reported Kubernetes API reachability
+//! - `k8s_api_latency_ms`: INTEGER, nullable; agent's self-reported Kubernetes API latency
+//! - `k8s_reported_at`: TIMESTAMPTZ, nullable; server-side ingestion time of the latest k8s report
 //!
 //! ## Usage
 //!

--- a/openapi/brokkr-v1.json
+++ b/openapi/brokkr-v1.json
@@ -3050,6 +3050,16 @@
               }
             },
             "description": "Failed to reload configuration"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Configuration hot-reload is not enabled on this broker"
           }
         },
         "security": [
@@ -3129,12 +3139,6 @@
         "security": [
           {
             "admin_pak": []
-          },
-          {
-            "agent_pak": []
-          },
-          {
-            "generator_pak": []
           }
         ],
         "tags": [
@@ -3192,12 +3196,6 @@
         "security": [
           {
             "admin_pak": []
-          },
-          {
-            "agent_pak": []
-          },
-          {
-            "generator_pak": []
           }
         ],
         "tags": [
@@ -3384,6 +3382,9 @@
         "security": [
           {
             "admin_pak": []
+          },
+          {
+            "agent_pak": []
           }
         ],
         "tags": [

--- a/sdks/python/brokkr-client/brokkr_broker_client/api/admin/reload_config.py
+++ b/sdks/python/brokkr-client/brokkr_broker_client/api/admin/reload_config.py
@@ -43,6 +43,11 @@ def _parse_response(
 
         return response_500
 
+    if response.status_code == 503:
+        response_503 = ErrorResponse.from_dict(response.json())
+
+        return response_503
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/sdks/typescript/brokkr-client/src/schema.d.ts
+++ b/sdks/typescript/brokkr-client/src/schema.d.ts
@@ -2811,6 +2811,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
+            /** @description Configuration hot-reload is not enabled on this broker */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     list_ws_connections: {


### PR DESCRIPTION
## What

Closes **BROKKR-T-0236** — the OpenAPI annotation-vs-enforcement mismatches the I-0029 docs audit surfaced. The docs already describe actual enforced behavior; this brings the spec (and one handler) into line.

## Changes

**Annotation drift (spec advertised access the code doesn't grant / vice versa):**
- `GET /agent-events`, `GET /agent-events/{id}` — drop `agent_pak`/`generator_pak` from `security()`; both enforce **admin-only** (`agent_events.rs:51,89`).
- `GET /agents/` (`search_agent`) — add `agent_pak`; the handler allows the **matching agent** in addition to admin (`agents.rs:282`).

**Real behavioral fix:**
- `POST /admin/config/reload` extracted `ReloadableConfig` as a **required** `Extension`, which **500'd before the admin check** when hot-reload is disabled (the extension isn't layered — `api/v1/mod.rs:72`). Now extracted as `Option`, **auth is checked first**, and a disabled broker returns a clean **503 `config_reload_disabled`**. Adds `ApiError::service_unavailable`.

**Docs accuracy:**
- `brokkr-models` agents module header listed only the legacy columns — added the k8s connectivity columns (`k8s_reachable`, `k8s_api_latency_ms`, `k8s_reported_at`).

**Reviewed and intentionally left as-is:**
- `add_target`/`remove_target` already annotate `admin_pak`+`generator_pak`; the "owning generator" part is a runtime ownership check OpenAPI security can't express — not a bug.
- `complete_work_order`'s 202 (`retry_scheduled`) is **intentionally** omitted from the spec, with a code comment explaining SDK generators require a single success type per operation. Left unchanged.

## Validation
- Regenerated `openapi/brokkr-v1.json` (+ client spec mirror) and the Python/TS SDKs.
- All three drift checks pass (`openapi check`, `check-python`, `check-typescript`).
- Broker unit tests: 116 passed. Existing admin-reload integration tests exercise the enabled path (fixtures always layer `ReloadableConfig`) and are unaffected; the new 503 is the disabled-path that was previously a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)