### PR TITLE
chore(release): bump lockstep version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-agent"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aquamarine",
  "axum",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-broker"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "brokkr-client",
  "clap",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-models"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "brokkr-utils",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-utils"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "config",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-wire"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "brokkr-models",
  "chrono",

--- a/charts/brokkr-agent/Chart.yaml
+++ b/charts/brokkr-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: brokkr-agent
 description: Brokkr Kubernetes cluster agent
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"
 # Shipwright integration (when enabled) requires Kubernetes >= 1.29
 kubeVersion: ">=1.29.0-0"
 

--- a/charts/brokkr-broker/Chart.yaml
+++ b/charts/brokkr-broker/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: brokkr-broker
 description: Brokkr control plane broker
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"
 
 dependencies:
   - name: postgresql

--- a/crates/brokkr-agent/Cargo.toml
+++ b/crates/brokkr-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-agent"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-broker/Cargo.toml
+++ b/crates/brokkr-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-broker"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-cli/Cargo.toml
+++ b/crates/brokkr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Command-line client for the Brokkr control plane: apply a folder of Kubernetes manifests as a stack's desired state."

--- a/crates/brokkr-client/Cargo.toml
+++ b/crates/brokkr-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-client"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-client/spec/brokkr-v1.json
+++ b/crates/brokkr-client/spec/brokkr-v1.json
@@ -2842,7 +2842,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/crates/brokkr-models/Cargo.toml
+++ b/crates/brokkr-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-models"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-utils/Cargo.toml
+++ b/crates/brokkr-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-utils"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-wire/Cargo.toml
+++ b/crates/brokkr-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-wire"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/openapi/brokkr-v1.json
+++ b/openapi/brokkr-v1.json
@@ -2842,7 +2842,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/sdks/python/brokkr-client/pyproject.toml
+++ b/sdks/python/brokkr-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client-generated"
-version = "0.8.0"
+version = "0.8.1"
 description = "A client library for accessing brokkr-broker"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/python/brokkr/pyproject.toml
+++ b/sdks/python/brokkr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client"
-version = "0.8.0"
+version = "0.8.1"
 description = "Ergonomic Python wrapper around the auto-generated brokkr-client-generated low-level client"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/typescript/brokkr-client/package.json
+++ b/sdks/typescript/brokkr-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colliery-io/brokkr-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Auto-generated TypeScript client for the Brokkr broker API",
   "license": "Elastic-2.0",
   "repository": {


### PR DESCRIPTION
## What

Lockstep patch bump **0.8.0 → 0.8.1** ahead of tagging `v0.8.1`.

## Why a patch release

Interface-correctness fixes landed on `main` **after** the `v0.8.0` tag and are currently unreleased — most importantly the OpenAPI annotation reconciliation from #75, which regenerated the spec and the Python/TS SDKs:

- `agent-events` endpoints corrected to admin-only in the spec.
- `GET /agents/` (search) corrected to admin-or-matching-agent.
- New `config_reload_disabled` **503** response (graceful behavior when hot-reload is off).

These are backward-compatible bug fixes to the published interface/SDKs → **patch**. Tagging `v0.8.1` publishes the corrected SDKs, spec, images, and charts.

## Files bumped (lockstep)
7 crate `Cargo.toml`s · 2 Helm `Chart.yaml` (version + appVersion) · 3 SDK manifests · OpenAPI `info.version` (regenerated, mirrored to client spec) · `Cargo.lock`.

The spec diff is **only** `info.version` (0.8.0 → 0.8.1) — the annotation corrections were already merged via #75; this release simply publishes them.

## Verification
`angreal openapi check` / `check-python` / `check-typescript` all pass. `verify-version` in `release.yml` will assert tag == crate versions.