### PR TITLE
feat(helm): source sensitive credentials from existing Secrets

### DIFF
--- a/.metis/backlog/features/BROKKR-T-0266.md
+++ b/.metis/backlog/features/BROKKR-T-0266.md
@@ -1,0 +1,75 @@
+---
+id: helm-source-sensitive-credentials
+level: task
+title: "Helm: source sensitive credentials from existing Secrets (agent PAK + broker webhook key/PAK hash)"
+short_code: "BROKKR-T-0266"
+created_at: 2026-06-29T19:18:16.961285+00:00
+updated_at: 2026-06-29T19:18:16.961285+00:00
+parent: 
+blocked_by: []
+archived: false
+
+tags:
+  - "#task"
+  - "#phase/backlog"
+  - "#feature"
+
+
+exit_criteria_met: false
+initiative_id: NULL
+---
+
+# Helm: source sensitive credentials from existing Secrets (agent PAK + broker webhook key/PAK hash)
+
+## Objective
+
+Let operators source sensitive Helm credentials from a pre-existing Kubernetes Secret instead of baking them into a ConfigMap or committing them to values/git. Originated from operator feedback on the agent chart (GitOps / external-secrets-operator workflows), then extended to the broker.
+
+Ships as a **template-only, backward-compatible change** — `appVersion` stays `0.8.3` (same container images), so it can be delivered as an out-of-band chart re-deploy/overwrite, **not** a full lockstep release. See [[project_release_versioning]].
+
+## Backlog Item Details
+
+### Type
+- [x] Feature - New functionality or enhancement
+
+### Priority
+- [x] P1 - High (security/GitOps gap; sensitive creds were only available as ConfigMap plaintext)
+
+### Business Justification
+- **User Value**: PAK / webhook encryption key / admin PAK hash can be vended by external-secrets-operator (Vault / 1Password / AWS Secrets Manager) into a k8s Secret; the raw credential never touches a values file or git history.
+- **Effort Estimate**: S
+
+## Problem
+
+- **Agent**: `BROKKR__AGENT__PAK` was always rendered into the ConfigMap from `broker.pak`. The README documented an `extraEnv`-based Secret workaround, but `extraEnv` was **never wired into the agent deployment template** — so there was genuinely no working way to source the PAK from a Secret.
+- **Broker**: `BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY` and `BROKKR__BROKER__PAK_HASH` were rendered as ConfigMap plaintext (DB URL already had `postgresql.existingSecret`).
+
+## Acceptance Criteria
+
+- [x] Agent: `broker.existingSecret` + `broker.existingSecretKey` (default `BROKKR__AGENT__PAK`) added; PAK injected via `secretKeyRef`; ConfigMap emits empty PAK when set.
+- [x] Broker: `broker.webhookEncryptionKeyExistingSecret`/`...Key` and `broker.pakHashExistingSecret`/`...Key` added; injected via `secretKeyRef`; plaintext keys omitted from ConfigMap when the existingSecret variant is set.
+- [x] Default behavior unchanged when no existingSecret is set (backward compatible).
+- [x] No plaintext credential leaks into the ConfigMap when an existingSecret is configured.
+- [x] READMEs updated; the broken agent `extraEnv` workaround replaced with the first-class option.
+- [x] `helm lint` clean and `helm template` verified for both charts (default + existingSecret paths, incl. agent existingSecret + namespace-scoped RBAC combined).
+
+## Implementation Notes
+
+### Technical Approach
+Used `env:` + `secretKeyRef` rather than the originally-proposed `envFrom:` + `secretRef`:
+- Makes `existingSecretKey` **functional** — `envFrom: secretRef` imports the whole Secret and ignores the key (the key would have to always equal the env var name).
+- Least-privilege: imports only the one key.
+- Kubernetes applies `env` after `envFrom`, so the Secret value deterministically overrides the ConfigMap value.
+
+Agent deployment merges the new PAK entry with the existing namespace-scoped-RBAC `env` block (`WATCH_NAMESPACE`); the block now renders when either condition holds.
+
+### Files changed
+- `charts/brokkr-agent/`: `values.yaml`, `templates/configmap.yaml`, `templates/deployment.yaml`, `README.md`
+- `charts/brokkr-broker/`: `values.yaml`, `templates/configmap.yaml`, `templates/deployment.yaml`, `README.md`
+
+### Release / rollout
+Out-of-band chart re-package + push (manual), reusing 0.8.3 app images. The release pipeline (`release.yml` `publish-helm-charts`) packages charts with `--version`/`--app-version` = git tag, so this intentionally bypasses the normal lockstep tag path.
+
+## Status Updates
+
+- 2026-06-29: Implemented across both charts; `helm lint` clean, `helm template` verified for default + existingSecret paths (agent, agent+namespaced RBAC, broker both secrets) with no plaintext ConfigMap leak. Pending: commit + manual out-of-band chart publish.

--- a/charts/brokkr-agent/README.md
+++ b/charts/brokkr-agent/README.md
@@ -71,20 +71,26 @@ Rendered into the agent ConfigMap as the `BROKKR__AGENT__GENERATOR_IDS` environm
 variable (equivalently settable via `agent.generator_ids` in a config file or the
 `--generator-ids` CLI flag).
 
-**Security Note**: The PAK is a sensitive credential. In production, use Kubernetes secrets:
+**Security Note**: The PAK is a sensitive credential. Setting `broker.pak` renders it
+into the agent ConfigMap in plaintext — fine for dev/test, but in production (and any
+GitOps workflow) source it from a pre-existing Kubernetes Secret via `broker.existingSecret`:
 
 ```bash
+# Secret keyed to match the env var name (the default existingSecretKey):
 kubectl create secret generic agent-credentials \
-  --from-literal=pak=your-pak-token
+  --from-literal=BROKKR__AGENT__PAK=your-pak-token
 
 helm install my-agent charts/brokkr-agent \
   --set broker.url=http://my-broker:3000 \
   --set broker.clusterName=production \
-  --set broker.pak="" \
-  --set-string 'extraEnv[0].name=BROKKR__AGENT__PAK' \
-  --set-string 'extraEnv[0].valueFrom.secretKeyRef.name=agent-credentials' \
-  --set-string 'extraEnv[0].valueFrom.secretKeyRef.key=pak'
+  --set broker.existingSecret=agent-credentials
 ```
+
+The PAK is injected into the pod via `secretKeyRef` (overriding the ConfigMap), so the
+raw credential never lands in a values file or git history. If your Secret stores the PAK
+under a different key, set `broker.existingSecretKey` to match. This pairs naturally with
+[external-secrets-operator](https://external-secrets.io/), which can vend the PAK from
+Vault / 1Password / AWS Secrets Manager into the Secret at deploy time.
 
 ### Agent Polling Configuration
 
@@ -216,7 +222,9 @@ securityContext:
 | `broker.url` | string | `"http://brokkr-broker:3000"` | Broker service URL |
 | `broker.agentName` | string | `""` | Agent identifier (auto-generated if empty) |
 | `broker.clusterName` | string | `""` | Cluster identifier |
-| `broker.pak` | string | `""` | Pre-Authenticated Key for authentication |
+| `broker.pak` | string | `""` | Pre-Authenticated Key (rendered into the ConfigMap in plaintext; dev/test only). Ignored when `broker.existingSecret` is set. |
+| `broker.existingSecret` | string | `""` | Name of a pre-existing Secret to source the PAK from. When set, the PAK is injected via `secretKeyRef` and kept out of the ConfigMap/values/git (GitOps-friendly). |
+| `broker.existingSecretKey` | string | `"BROKKR__AGENT__PAK"` | Key within `broker.existingSecret` holding the PAK. |
 | `broker.generatorIds` | list/string | `[]` | Generator UUIDs the agent self-registers with on startup (`BROKKR__AGENT__GENERATOR_IDS`). Empty = system/fleet scope only. |
 | `agent.pollingInterval` | int | `30` | Polling interval in seconds |
 | `rbac.create` | bool | `true` | Create RBAC resources |

--- a/charts/brokkr-agent/templates/configmap.yaml
+++ b/charts/brokkr-agent/templates/configmap.yaml
@@ -14,7 +14,10 @@ data:
   # agent derives the WS URL from BROKKR__AGENT__BROKER_URL. See ADR-0008.
   BROKKR__AGENT__WS_URL: {{ .Values.agent.wsUrl | quote }}
   {{- end }}
-  BROKKR__AGENT__PAK: {{ .Values.broker.pak | quote }}
+  {{- /* When existingSecret is set the PAK is injected via secretKeyRef in the
+         deployment (env overrides envFrom), so keep the raw credential out of
+         the ConfigMap entirely. */}}
+  BROKKR__AGENT__PAK: {{ if .Values.broker.existingSecret }}""{{ else }}{{ .Values.broker.pak | quote }}{{ end }}
   {{- with .Values.broker.generatorIds }}
   # Generator scopes the agent self-registers with on startup (BROKKR-I-0030).
   # Comma-separated generator UUIDs; unset/empty = system/fleet scope only.

--- a/charts/brokkr-agent/templates/deployment.yaml
+++ b/charts/brokkr-agent/templates/deployment.yaml
@@ -56,14 +56,25 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "brokkr-agent.fullname" . }}
-        {{- if not .Values.rbac.clusterWide }}
+        {{- if or (not .Values.rbac.clusterWide) .Values.broker.existingSecret }}
         env:
+        {{- if not .Values.rbac.clusterWide }}
         # Namespace-scoped RBAC: restrict the agent's watchers and health
         # discovery to the release namespace (BROKKR-T-0192).
         - name: BROKKR__AGENT__WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- end }}
+        {{- if .Values.broker.existingSecret }}
+        # Source the PAK from a pre-existing Secret (GitOps-friendly). An explicit
+        # env entry overrides the ConfigMap's BROKKR__AGENT__PAK from envFrom.
+        - name: BROKKR__AGENT__PAK
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.broker.existingSecret }}
+              key: {{ .Values.broker.existingSecretKey | default "BROKKR__AGENT__PAK" }}
+        {{- end }}
         {{- end }}
         volumeMounts:
         # Writable /tmp directory (required for read-only root filesystem)

--- a/charts/brokkr-agent/values.yaml
+++ b/charts/brokkr-agent/values.yaml
@@ -66,7 +66,17 @@ broker:
   url: http://brokkr-broker:3000
   agentName: ""
   clusterName: ""
+  # Pre-Authenticated Key. Used only when broker.existingSecret is empty.
+  # WARNING: a value here is rendered into the agent ConfigMap in plaintext —
+  # for GitOps / production, prefer broker.existingSecret below.
   pak: ""
+  # Source the PAK from a pre-existing Kubernetes Secret instead of broker.pak.
+  # When set, the ConfigMap omits the PAK and the deployment injects
+  # BROKKR__AGENT__PAK from this Secret via secretKeyRef (overriding the
+  # ConfigMap). Lets the raw credential stay out of values files / git history —
+  # e.g. vended by external-secrets-operator from Vault / 1Password / AWS SM.
+  existingSecret: ""                       # name of the pre-existing Secret
+  existingSecretKey: "BROKKR__AGENT__PAK"  # key within that Secret holding the PAK
   # Generator scopes this agent serves. Each entry is a generator UUID; the agent
   # self-registers with each on startup so the broker will only target it with
   # stacks owned by these generators (see ADR-0009, BROKKR-I-0030).

--- a/charts/brokkr-broker/README.md
+++ b/charts/brokkr-broker/README.md
@@ -320,6 +320,12 @@ securityContext:
 | `postgresql.external.password` | string | `"brokkr"` | Database password |
 | `postgresql.external.schema` | string | `""` | PostgreSQL schema for multi-tenant isolation |
 | `postgresql.existingSecret` | string | `""` | Existing secret for database URL |
+| `broker.webhookEncryptionKey` | string | `""` | Webhook encryption key (rendered into the ConfigMap in plaintext; dev/test only). Ignored when `broker.webhookEncryptionKeyExistingSecret` is set. |
+| `broker.webhookEncryptionKeyExistingSecret` | string | `""` | Name of a pre-existing Secret to source the webhook encryption key from. Injected via `secretKeyRef`, kept out of the ConfigMap/values/git (GitOps-friendly). |
+| `broker.webhookEncryptionKeyExistingSecretKey` | string | `"BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY"` | Key within that Secret holding the webhook encryption key. |
+| `broker.pakHash` | string | `""` | Admin PAK hash (rendered into the ConfigMap in plaintext; dev/test only). Ignored when `broker.pakHashExistingSecret` is set. |
+| `broker.pakHashExistingSecret` | string | `""` | Name of a pre-existing Secret to source the admin PAK hash from. Injected via `secretKeyRef`. |
+| `broker.pakHashExistingSecretKey` | string | `"BROKKR__BROKER__PAK_HASH"` | Key within that Secret holding the admin PAK hash. |
 | `tls.enabled` | bool | `false` | Enable TLS/SSL |
 | `tls.existingSecret` | string | `""` | Existing TLS secret name |
 | `tls.cert` | string | `""` | Base64-encoded certificate (testing only) |

--- a/charts/brokkr-broker/templates/configmap.yaml
+++ b/charts/brokkr-broker/templates/configmap.yaml
@@ -54,12 +54,15 @@ data:
   BROKKR__BROKER__WEBHOOK_DELIVERY_INTERVAL_SECONDS: {{ .Values.broker.webhookDeliveryIntervalSeconds | default 5 | quote }}
   BROKKR__BROKER__WEBHOOK_DELIVERY_BATCH_SIZE: {{ .Values.broker.webhookDeliveryBatchSize | default 50 | quote }}
   BROKKR__BROKER__WEBHOOK_CLEANUP_RETENTION_DAYS: {{ .Values.broker.webhookCleanupRetentionDays | default 7 | quote }}
-  {{- if .Values.broker.webhookEncryptionKey }}
+  {{- if and .Values.broker.webhookEncryptionKey (not .Values.broker.webhookEncryptionKeyExistingSecret) }}
   # Webhook encryption key (static - requires restart)
+  # When webhookEncryptionKeyExistingSecret is set, the key is injected via
+  # secretKeyRef in the deployment instead and omitted here.
   BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY: {{ .Values.broker.webhookEncryptionKey | quote }}
   {{- end }}
-  {{- if .Values.broker.pakHash }}
+  {{- if and .Values.broker.pakHash (not .Values.broker.pakHashExistingSecret) }}
   # Admin PAK hash (static - requires restart)
+  # When pakHashExistingSecret is set, injected via secretKeyRef instead.
   BROKKR__BROKER__PAK_HASH: {{ .Values.broker.pakHash | quote }}
   {{- end }}
   {{- end }}

--- a/charts/brokkr-broker/templates/deployment.yaml
+++ b/charts/brokkr-broker/templates/deployment.yaml
@@ -63,6 +63,23 @@ spec:
               name: {{ .Values.postgresql.existingSecret }}
               key: {{ .Values.postgresql.existingSecretKey | default "database-url" }}
         {{- end }}
+        {{- if .Values.broker.webhookEncryptionKeyExistingSecret }}
+        # Source the webhook encryption key from a pre-existing Secret (GitOps-friendly).
+        # An explicit env entry overrides the ConfigMap value from envFrom.
+        - name: BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.broker.webhookEncryptionKeyExistingSecret }}
+              key: {{ .Values.broker.webhookEncryptionKeyExistingSecretKey | default "BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY" }}
+        {{- end }}
+        {{- if .Values.broker.pakHashExistingSecret }}
+        # Source the admin PAK hash from a pre-existing Secret (GitOps-friendly).
+        - name: BROKKR__BROKER__PAK_HASH
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.broker.pakHashExistingSecret }}
+              key: {{ .Values.broker.pakHashExistingSecretKey | default "BROKKR__BROKER__PAK_HASH" }}
+        {{- end }}
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/brokkr-broker/values.yaml
+++ b/charts/brokkr-broker/values.yaml
@@ -204,7 +204,25 @@ broker:
   # @hot-reload: false - requires restart
   # If not set, a random key is generated on startup
   # WARNING: Changing this will make existing encrypted webhook data unreadable
+  # WARNING: a value here is rendered into the broker ConfigMap in plaintext —
+  # for GitOps / production, prefer the existingSecret option below.
   # webhookEncryptionKey: ""
+  # Source the webhook encryption key from a pre-existing Kubernetes Secret
+  # instead of webhookEncryptionKey. When set, the key is injected via
+  # secretKeyRef (overriding the ConfigMap) and never touches values/git —
+  # e.g. vended by external-secrets-operator from Vault / 1Password / AWS SM.
+  webhookEncryptionKeyExistingSecret: ""                                    # name of the pre-existing Secret
+  webhookEncryptionKeyExistingSecretKey: BROKKR__BROKER__WEBHOOK_ENCRYPTION_KEY  # key within that Secret
+
+  # Admin PAK hash for day-zero bootstrap (BROKKR__BROKER__PAK_HASH).
+  # @hot-reload: false - requires restart
+  # WARNING: a value here is rendered into the broker ConfigMap in plaintext —
+  # for GitOps / production, prefer the existingSecret option below.
+  # pakHash: ""
+  # Source the admin PAK hash from a pre-existing Kubernetes Secret instead of
+  # pakHash. When set, injected via secretKeyRef (overriding the ConfigMap).
+  pakHashExistingSecret: ""                            # name of the pre-existing Secret
+  pakHashExistingSecretKey: BROKKR__BROKER__PAK_HASH   # key within that Secret
 
 # CORS configuration for API access
 # @hot-reload: true - changes apply without restart (except allowCredentials)


### PR DESCRIPTION
## Summary

Lets operators source sensitive Helm credentials from a **pre-existing Kubernetes Secret** instead of baking them into a ConfigMap or committing them to values/git — for GitOps / external-secrets-operator (Vault, 1Password, AWS Secrets Manager) workflows. Originated from operator feedback on the agent chart, then extended to the broker.

**Template-only and backward-compatible** — `appVersion` stays `0.8.3` (same container images). Intended to ship as an out-of-band chart re-publish/overwrite, **not** a full lockstep release.

## Agent chart
- New `broker.existingSecret` + `broker.existingSecretKey` (default `BROKKR__AGENT__PAK`).
- When set, the PAK is injected via `secretKeyRef` and the ConfigMap emits an empty PAK.
- Replaces the README's `extraEnv` Secret workaround, which **was never actually wired into the agent deployment template** — there was previously no working way to source the PAK from a Secret.

## Broker chart
- New `broker.webhookEncryptionKeyExistingSecret`/`...Key` and `broker.pakHashExistingSecret`/`...Key`.
- Injected via `secretKeyRef`; plaintext keys omitted from the ConfigMap when set (DB URL already had `postgresql.existingSecret`).

## Design note
Uses `env:` + `secretKeyRef` rather than the originally-proposed `envFrom:` + `secretRef`:
- Makes `existingSecretKey` **functional** (`envFrom: secretRef` imports the whole Secret and ignores the key).
- Least-privilege: only the one key is imported.
- `env` is applied after `envFrom`, so the Secret value deterministically overrides the ConfigMap.

## Validation
- `helm lint` clean on both charts.
- `helm template` verified: default paths unchanged (plaintext in ConfigMap, no secretKeyRef); existingSecret paths inject via secretKeyRef with **no plaintext leak** into the ConfigMap; agent existingSecret + namespace-scoped RBAC combined renders both `env` entries.

## Rollout
After merge: separate out-of-band manual chart re-package + push (overwrite), reusing 0.8.3 app images.

Refs BROKKR-T-0266