### PR TITLE
ci: one-off workflow to re-publish Helm charts (overwrite, no release)

### DIFF
--- a/.github/workflows/oneoff-publish-helm.yml
+++ b/.github/workflows/oneoff-publish-helm.yml
@@ -1,0 +1,66 @@
+name: One-off — Publish Helm charts (overwrite, no release)
+
+# =============================================================================
+# TEMPORARY, one-off workflow — DELETE after firing.
+#
+# Re-packages and pushes the brokkr-agent and brokkr-broker Helm charts to the
+# OCI registry at an EXISTING app version, WITHOUT cutting a new git tag or
+# triggering release.yml / release-sdks.yml. Used to ship a template-only chart
+# change (e.g. broker.existingSecret, BROKKR-T-0266) on top of already-released
+# container images, overwriting the existing chart tag.
+#
+# This intentionally bypasses the lockstep, tag-driven `publish-helm-charts`
+# job in release.yml. Fire once from the Actions tab ("Run workflow"), then
+# remove this file.
+# =============================================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Chart version / appVersion to package and push (overwrites the existing OCI tag)"
+        required: true
+        default: "0.8.3"
+
+jobs:
+  publish:
+    name: Package & push charts
+    runs-on: ubuntu-latest
+    # Same gated environment as the normal publish job, so this still requires
+    # human approval before it can push (see release approval gates).
+    environment:
+      name: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: 'v3.12.0'
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add openfunction https://openfunction.github.io/charts/
+
+      - name: Build Helm dependencies
+        run: |
+          helm dependency build charts/brokkr-broker
+          helm dependency build charts/brokkr-agent
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GHCR_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push Helm charts to OCI registry (overwrite)
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "Publishing brokkr-agent and brokkr-broker charts at version ${VERSION} (overwriting existing tag)"
+
+          helm package charts/brokkr-broker --version "${VERSION}" --app-version "${VERSION}"
+          helm push "brokkr-broker-${VERSION}.tgz" oci://ghcr.io/${{ github.repository_owner }}/charts
+
+          helm package charts/brokkr-agent --version "${VERSION}" --app-version "${VERSION}"
+          helm push "brokkr-agent-${VERSION}.tgz" oci://ghcr.io/${{ github.repository_owner }}/charts


### PR DESCRIPTION
## Summary

Temporary `workflow_dispatch`-only workflow to re-package and push the **brokkr-agent** and **brokkr-broker** Helm charts to GHCR at an existing app version (default `0.8.3`) **without** cutting a git tag or triggering `release.yml` / `release-sdks.yml`.

This ships the `existingSecret` chart change (BROKKR-T-0266, merged in #83) on top of the already-released 0.8.3 container images, overwriting the existing chart OCI tag.

## Notes
- Mirrors `release.yml`'s `publish-helm-charts` auth/setup (Helm v3.12.0, `bitnami`/`openfunction` repos, `helm dependency build`, GHCR login via `secrets.GHCR_TOKEN`) **minus** the tag-driven release/GitHub-Release steps.
- Runs under the gated `release` environment, so firing it still requires the usual human approval before the push.
- `version` input defaults to `0.8.3`; override if needed.

## Lifecycle
Must live on `main` for the "Run workflow" button to appear. Plan: merge → fire once from the Actions tab → delete this file in a follow-up.

Refs BROKKR-T-0266