### PR TITLE
ci: drop release environment from one-off helm publish

### DIFF
--- a/.github/workflows/oneoff-publish-helm.yml
+++ b/.github/workflows/oneoff-publish-helm.yml
@@ -26,10 +26,10 @@ jobs:
   publish:
     name: Package & push charts
     runs-on: ubuntu-latest
-    # Same gated environment as the normal publish job, so this still requires
-    # human approval before it can push (see release approval gates).
-    environment:
-      name: release
+    # NOTE: intentionally NOT using `environment: release`. That environment's
+    # deployment-branch policy only permits tag refs, so a workflow_dispatch from
+    # main is rejected. GHCR_TOKEN is a repo-level secret, so no environment is
+    # needed; the manual dispatch itself is the gate.
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The `release` environment's deployment-branch policy only permits tag refs, so the one-off `workflow_dispatch` from `main` was rejected (`Branch "main" is not allowed to deploy to release`). `GHCR_TOKEN` is a repo-level secret, so the gated environment isn't needed — the manual dispatch is the gate. Refs BROKKR-T-0266