### PR TITLE
test(e2e): register before asserting label-based targeting

### DIFF
--- a/tests/e2e/src/scenarios.rs
+++ b/tests/e2e/src/scenarios.rs
@@ -259,17 +259,26 @@ pub async fn test_targeting(client: &Client) -> Result<()> {
     client.add_stack_label(stack_id, "targeting-test").await?;
     println!("    Created stack with label 'targeting-test'");
 
+    // Registration is the consent boundary for **every** association path,
+    // label matching included (BROKKR-T-0287). Before that change this call sat
+    // below the label assertion, because only explicit targets required it —
+    // so a label match reached across a generator the agent had never
+    // registered with. It now has to happen first or the stack is correctly
+    // withheld.
+    client
+        .register_agent_with_generator(generator_id, agent_id)
+        .await?;
+    println!("    Registered agent with generator");
+
     // Verify label matching
     println!("  → Verifying label-based targeting...");
     let agent_stacks = client.get_agent_stacks(agent_id).await?;
     let has_stack = agent_stacks.iter().any(|s| s["id"] == stack_id.to_string());
-    assert!(has_stack, "Agent should see stack via label matching");
+    assert!(
+        has_stack,
+        "Agent should see stack via label matching once registered with its generator"
+    );
     println!("    Agent sees stack via label matching ✓");
-
-    // Register agent with generator before explicit targeting.
-    client
-        .register_agent_with_generator(generator_id, agent_id)
-        .await?;
 
     // Test explicit targeting
     println!("  → Testing explicit targeting...");


### PR DESCRIPTION
The nightly on `main` after #89 failed at `scenarios.rs:266` — *"Agent should see stack via label matching"*.

**The code is right; the test encoded the old semantics.**

`test_targeting` created an agent and a stack under a generator the agent was never registered with, then asserted the label match delivered the stack. BROKKR-T-0287 made registration the consent boundary for *every* association path — label and annotation matches included, not just explicit targets — so the broker now correctly withholds it.

The test gave itself away: `register_agent_with_generator` sat *below* the assertion, under the comment "Register agent with generator before explicit targeting". That was accurate before T-0287 and stale after. Moved above the assertion, comment rewritten.

### Why it surfaced now

e2e only runs on nightly/release, so the PR checks could not have caught it. Yesterday's nightly passed; this one failed on the first run after #89 merged — which is exactly what running a nightly before tagging was meant to find.

### Release note

This is the behavioural change to call out in 0.9.0: **an agent receiving stacks via a label match from a generator it is not registered with stops receiving them on upgrade.** The e2e suite was the last place still encoding the pre-consent behaviour.

### Unrelated failure in the same run

`Prune Stale GHCR Images` failed for both broker and agent with `delete version API failed. Package not found.` — not touched here.