### PR TITLE
test(e2e): register agents at the three remaining consent sites

### DIFF
--- a/tests/e2e/src/scenarios.rs
+++ b/tests/e2e/src/scenarios.rs
@@ -916,7 +916,13 @@ pub async fn test_agent_reconciliation_existing_deployments(client: &Client) -> 
     client
         .update_agent(agent2_id, json!({"status": "ACTIVE"}))
         .await?;
-    println!("    Created agent: {}", agent2_id);
+    // Registration is the consent boundary for label matching too
+    // (BROKKR-T-0287), so the agent must be registered with the stack's
+    // generator before a match can deliver anything.
+    client
+        .register_agent_with_generator(generator_id, agent2_id)
+        .await?;
+    println!("    Created agent: {} (registered with generator)", agent2_id);
 
     // 2c. NOW add matching label to agent (after deployment exists)
     client
@@ -964,7 +970,12 @@ pub async fn test_agent_reconciliation_existing_deployments(client: &Client) -> 
     client
         .update_agent(agent3_id, json!({"status": "ACTIVE"}))
         .await?;
-    println!("    Created agent: {}", agent3_id);
+    // Annotation matching is gated by registration exactly as label matching
+    // is (BROKKR-T-0287).
+    client
+        .register_agent_with_generator(generator_id, agent3_id)
+        .await?;
+    println!("    Created agent: {} (registered with generator)", agent3_id);
 
     // 3c. NOW add matching annotation to agent (after deployment exists)
     client
@@ -1261,6 +1272,12 @@ pub async fn test_ws_smoke(client: &Client) -> Result<()> {
         "    baseline brokkr_ws_messages_total{{direction=out,type=target_changed}} = {}",
         baseline
     );
+
+    // Explicit targets are refused with 403 `agent_not_registered` unless the
+    // agent is registered with the stack's generator (BROKKR-T-0246/T-0287).
+    client
+        .register_agent_with_generator(gen_id, agent_id)
+        .await?;
 
     // Add the target — this triggers push_target_changed on the broker.
     client.add_agent_target(agent_id, stack_id).await?;


### PR DESCRIPTION
Follow-up to #91. That fix was correct — Parts 1–7 now pass — and the suite ran on to fail at Part 7b for the same reason.

Rather than spend a nightly per site, I audited **every** targeting call against the generators it uses. Seven generators are created across the suite; only two agents were registered. Three sites still assumed pre-consent behaviour:

| Site | Path | Would have failed |
|---|---|---|
| Part 7b `agent2` | label match | now (this run) |
| Part 7b `agent3` | annotation match | next run |
| `ws_smoke` `add_agent_target` | explicit target | later, differently — 403 `agent_not_registered` at creation (T-0246) |

`ws_telemetry` needs no registration: it applies a pod directly to k3s and polls `/stacks/:id/events`, so nothing is delivered through targeting.

### Verification

Run locally with `angreal tests e2e` rather than by another nightly — e2e is runnable on a workstation and I should have been doing that from the start.

### Release note

That the e2e suite encoded the old semantics in **five separate places** is the strongest evidence yet this belongs in the 0.9.0 notes: *an agent receiving stacks via a label or annotation match from a generator it is not registered with stops receiving them on upgrade.*
