### PR TITLE
chore(release): bump to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-agent"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aquamarine",
  "axum",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-broker"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "brokkr-client",
  "clap",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-client"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-models"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "brokkr-utils",
  "chrono",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "config",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-wire"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "brokkr-models",
  "chrono",

--- a/charts/brokkr-agent/Chart.yaml
+++ b/charts/brokkr-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: brokkr-agent
 description: Brokkr Kubernetes cluster agent
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.9.1
+appVersion: "0.9.1"
 # Shipwright integration (when enabled) requires Kubernetes >= 1.29
 kubeVersion: ">=1.29.0-0"
 

--- a/charts/brokkr-agent/README.md
+++ b/charts/brokkr-agent/README.md
@@ -355,7 +355,7 @@ entries left in your values files, but you should delete them.
 
 ## Values
 
-This table covers **every key in `values.yaml`** for chart version 0.9.0, plus the keys the
+This table covers **every key in `values.yaml`** for chart version 0.9.1, plus the keys the
 templates read that `values.yaml` only mentions in comments (marked *not in values.yaml*).
 It is hand-maintained, so `values.yaml` remains the authoritative source — check it with
 `helm show values charts/brokkr-agent` (or `oci://ghcr.io/colliery-io/charts/brokkr-agent`)

--- a/charts/brokkr-broker/Chart.yaml
+++ b/charts/brokkr-broker/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: brokkr-broker
 description: Brokkr control plane broker
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.9.1
+appVersion: "0.9.1"
 
 dependencies:
   - name: postgresql

--- a/charts/brokkr-broker/README.md
+++ b/charts/brokkr-broker/README.md
@@ -372,7 +372,7 @@ next upgrade.
 
 ## Values
 
-This table covers **every key in `values.yaml`** for chart version 0.9.0, plus the keys the
+This table covers **every key in `values.yaml`** for chart version 0.9.1, plus the keys the
 templates read that `values.yaml` only mentions in comments (marked *not in values.yaml*).
 It is hand-maintained, so `values.yaml` remains the authoritative source — check it with
 `helm show values charts/brokkr-broker` (or `oci://ghcr.io/colliery-io/charts/brokkr-broker`)

--- a/crates/brokkr-agent/Cargo.toml
+++ b/crates/brokkr-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-agent"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-broker/Cargo.toml
+++ b/crates/brokkr-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-broker"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-cli/Cargo.toml
+++ b/crates/brokkr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Command-line client for the Brokkr control plane: apply a folder of Kubernetes manifests as a stack's desired state."

--- a/crates/brokkr-client/Cargo.toml
+++ b/crates/brokkr-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-client"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-client/spec/brokkr-v1.json
+++ b/crates/brokkr-client/spec/brokkr-v1.json
@@ -2950,7 +2950,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.9.0"
+    "version": "0.9.1"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/crates/brokkr-models/Cargo.toml
+++ b/crates/brokkr-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-models"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-utils/Cargo.toml
+++ b/crates/brokkr-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-utils"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brokkr-web/Cargo.lock
+++ b/crates/brokkr-web/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "brokkr-web"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aurora-leptos",
  "gloo-net",
@@ -518,9 +518,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "html-escape"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "http"

--- a/crates/brokkr-web/Cargo.toml
+++ b/crates/brokkr-web/Cargo.toml
@@ -3,7 +3,7 @@
 # served by the broker. Has its own Cargo.lock.
 [package]
 name = "brokkr-web"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Elastic-2.0"
 description = "Brokkr Operator Console — a read-mostly Leptos/WASM monitoring console served by the broker."

--- a/crates/brokkr-wire/Cargo.toml
+++ b/crates/brokkr-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brokkr-wire"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/openapi/brokkr-v1.json
+++ b/openapi/brokkr-v1.json
@@ -2950,7 +2950,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "brokkr-broker",
-    "version": "0.9.0"
+    "version": "0.9.1"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/sdks/python/brokkr-client/pyproject.toml
+++ b/sdks/python/brokkr-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client-generated"
-version = "0.9.0"
+version = "0.9.1"
 description = "A client library for accessing brokkr-broker"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/python/brokkr/pyproject.toml
+++ b/sdks/python/brokkr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brokkr-client"
-version = "0.9.0"
+version = "0.9.1"
 description = "Ergonomic Python wrapper around the auto-generated brokkr-client-generated low-level client"
 authors = []
 requires-python = ">=3.10"

--- a/sdks/typescript/brokkr-client/package.json
+++ b/sdks/typescript/brokkr-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colliery-io/brokkr-client",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Auto-generated TypeScript client for the Brokkr broker API",
   "license": "Elastic-2.0",
   "repository": {


### PR DESCRIPTION
Release prep for 0.9.1, carrying T-0292 (hot reload made real) and the config-watcher fix it surfaced.

Bumped: 8 crate manifests, both Python pyprojects, the TypeScript `package.json`, both `Chart.yaml` files and the chart README stamps. Both lockfiles regenerated.

**Spec and SDKs regenerated.** The OpenAPI document embeds the crate version, so a bump on its own leaves the committed spec stale and fails the required drift check — that caught us at 0.9.0, so it's done up front here.

Verified locally against `TAG=0.9.1`:
- `verify-version`'s exact check — all versions agree
- `openapi check`, `check-python`, `check-typescript` — all exit 0
- 57 chart render assertions, `helm lint`

### What ships in 0.9.1

- **T-0292** — hot reload actually reloads. Log level and the diagnostic/webhook tunables now apply without a restart; the chart delivers them as a mounted TOML file. CORS remains restart-only by decision.
- **Config watcher fix** — its event loop used a blocking `std::sync::mpsc::recv_timeout` inside `tokio::spawn`, starving the runtime so the broker never bound to :3000. Latent until T-0292 set `BROKKR_CONFIG_FILE` for the first time.
